### PR TITLE
Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This module lets one create one or more redundancy descriptors,
 which then may be applied to a set of files distributed across a group of processes.
 
-Usage is documented in [src/redset.h](src/redset.h) and [doc/rst/redset.rst](doc/rst/redset.rst).
+Usage is documented in [src/redset.h](src/redset.h), [doc/rst/redset.rst](doc/rst/redset.rst), and the [User API docs](https://ecp-veloc.github.io/component-user-docs/group__redset.html).
 Also see the example program in the [test](test) directory.
 
 Implementation details can be found in [doc/rst/implementation.rst](doc/rst/implementation.rst) and [doc/rst/schemes.rst](doc/rst/schemes.rst).

--- a/src/redset.h
+++ b/src/redset.h
@@ -4,6 +4,17 @@
 #include "mpi.h"
 #include "kvtree.h"
 
+/** \defgoup redset Redset
+ *  \brief Redundancy encoding file sets
+ *
+ * Redset will create the redundancy data needed for a set of
+ * files. It can rebuild a file with provided redundancy
+ * information. */
+
+/** \file redset.h
+ *  \ingroup redset
+ *  \brief redundancy sets */
+
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {
@@ -16,85 +27,81 @@ extern "C" {
 #define REDSET_COPY_PARTNER (2)
 #define REDSET_COPY_XOR     (3)
 
-/*
-=========================================
-Define redundancy descriptor structure
-=========================================
-*/
-
+/********************************************************/
+/** \name Define redundancy descriptor structure */
+///@{
 typedef void* redset;
 typedef void* redset_filelist;
+///@}
 
-/*
-=========================================
-Redundancy descriptor functions
-=========================================
-*/
+/********************************************************/
+/** \name Redundancy descriptor functions */
+///@{
 
-/* initialize library */
+/** initialize library */
 int redset_init();
 
-/* shutdown library */
+/** shutdown library */
 int redset_finalize();
 
-/* create a new redundancy set descriptor */
+/** create a new redundancy set descriptor */
 int redset_create(
-  int type,          /* IN  - redundancy encoding type: one of REDSET_COPY values */
-  MPI_Comm comm,     /* IN  - process group participating in set */
-  const char* group, /* IN  - string specifying procs in the same failure group */
-  redset* d          /* OUT - output redundancy descriptor */
+  int type,          /**< [IN]  - redundancy encoding type: one of REDSET_COPY values */
+  MPI_Comm comm,     /**< [IN]  - process group participating in set */
+  const char* group, /**< [IN]  - string specifying procs in the same failure group */
+  redset* d          /**< [OUT] - output redundancy descriptor */
 );
 
-/* free any memory associated with the specified redundancy descriptor */
+/** free any memory associated with the specified redundancy descriptor */
 int redset_delete(
-  redset* d /* INOUT - redundancy descriptor to be freed */
+  redset* d /**< [INOUT] - redundancy descriptor to be freed */
 );
 
-/* apply redundancy scheme to file and return number of bytes copied
+/** apply redundancy scheme to file and return number of bytes copied
  * in bytes parameter */
 int redset_apply(
-  int numfiles,       /* IN - number of file names in files array */
-  const char** files, /* IN - list of file names of length numfiles */
-  const char* name,   /* IN - path/filename prefix to prepend to redset metadata files */
-  const redset d      /* IN - redundancy decriptor to be applied */
+  int numfiles,       /**< [IN] - number of file names in files array */
+  const char** files, /**< [IN] - list of file names of length numfiles */
+  const char* name,   /**< [IN] - path/filename prefix to prepend to redset metadata files */
+  const redset d      /**< [IN] - redundancy decriptor to be applied */
 );
 
-/* rebuilds files for specified dataset id using specified redundancy descriptor,
+/** rebuilds files for specified dataset id using specified redundancy descriptor,
  * adds them to filemap, and returns REDSET_SUCCESS if all processes succeeded */
 int redset_recover(
-  MPI_Comm comm,    /* IN  - parent communicator containg set of processes rebuilding data */
-  const char* name, /* IN  - path/filename prefix to prepend to redset metadata files */
-  redset* d         /* OUT - output redundancy descriptor */
+  MPI_Comm comm,    /**< [IN]  - parent communicator containg set of processes rebuilding data */
+  const char* name, /**< [IN]  - path/filename prefix to prepend to redset metadata files */
+  redset* d         /**< [OUT] - output redundancy descriptor */
 );
 
-/* deletes redundancy data that was added in redset_apply,
+/** deletes redundancy data that was added in redset_apply,
  * which is useful when cleaning up */
 int redset_unapply(
-  const char* name, /* IN - path/filename prefix to prepend to redset metadata files */
-  const redset d    /* IN - redundancy descriptor associated with above path */
+  const char* name, /**< [IN] - path/filename prefix to prepend to redset metadata files */
+  const redset d    /**< [IN] - redundancy descriptor associated with above path */
 );
 
-/* return list of files added by redundancy scheme */
+/** return list of files added by redundancy scheme */
 redset_filelist redset_filelist_get(
-  const char* name, /* IN - path/filename prefix to prepend to redset metadata files */
-  const redset d    /* IN - redundancy descriptor associated with above path */
+  const char* name, /**< [IN] - path/filename prefix to prepend to redset metadata files */
+  const redset d    /**< [IN] - redundancy descriptor associated with above path */
 );
 
-/* free file list allocated by call to redset_filelist_get */
+/** free file list allocated by call to redset_filelist_get */
 int redset_filelist_release(
-  redset_filelist* plist /* INOUT - address of pointer to list to be freed, sets pointer to NULL */
+  redset_filelist* plist /**< [INOUT] - address of pointer to list to be freed, sets pointer to NULL */
 );
 
-/* return number of files in file list */
+/** return number of files in file list */
 int redset_filelist_count(
-  redset_filelist list /* IN - list of redundancy files */
+  redset_filelist list /**< [IN] - list of redundancy files */
 );
 
-/* return name of file at specified index, where
+/** return name of file at specified index, where
  * 0 <= index < count and count is value returned by redset_filelist_count */
 const char* redset_filelist_file(
-  redset_filelist list, /* IN - list of redundancy files */
-  int index             /* IN - index into list, ranges from 0 to list count - 1 */
+  redset_filelist list, /**< [IN] - list of redundancy files */
+  int index             /**< [IN] - index into list, ranges from 0 to list count - 1 */
 );
 
 /* enable C++ codes to include this header directly */

--- a/src/redset.h
+++ b/src/redset.h
@@ -4,7 +4,7 @@
 #include "mpi.h"
 #include "kvtree.h"
 
-/** \defgoup redset Redset
+/** \defgroup redset Redset
  *  \brief Redundancy encoding file sets
  *
  * Redset will create the redundancy data needed for a set of

--- a/src/redset_io.h
+++ b/src/redset_io.h
@@ -12,54 +12,56 @@
 #define REDSET_MAX_LINE (1024)
 #endif
 
-/*
-=========================================
-Basic File I/O
-=========================================
-*/
+/** \file redset_io.h
+ *  \ingroup redset
+ *  \brief I/O functions */
 
-/* returns user's current mode as determine by his umask */
+/********************************************************/
+/** \name Basic File I/O */
+///@{
+
+/** returns user's current mode as determine by his umask */
 mode_t redset_getmode(int read, int write, int execute);
 
-/* open file with specified flags and mode, retry open a few times on failure */
+/** open file with specified flags and mode, retry open a few times on failure */
 int redset_open(const char* file, int flags, ...);
 
-/* close file with an fsync */
+/** close file with an fsync */
 int redset_close(const char* file, int fd);
 
-/* get and release file locks */
+/** get and release file locks */
 int redset_file_lock_read(const char* file, int fd);
 int redset_file_lock_write(const char* file, int fd);
 int redset_file_unlock(const char* file, int fd);
 
-/* opens specified file and waits on for an exclusive lock before returning the file descriptor */
+/** opens specified file and waits on for an exclusive lock before returning the file descriptor */
 int redset_open_with_lock(const char* file, int flags, mode_t mode);
 
-/* unlocks the specified file descriptor and then closes the file */
+/** unlocks the specified file descriptor and then closes the file */
 int redset_close_with_unlock(const char* file, int fd);
 
-/* seek file descriptor to specified position */
+/** seek file descriptor to specified position */
 int redset_lseek(const char* file, int fd, off_t pos, int whence);
 
-/* reliable read from opened file descriptor (retries, if necessary, until hard error) */
+/** reliable read from opened file descriptor (retries, if necessary, until hard error) */
 ssize_t redset_read(const char* file, int fd, void* buf, size_t size);
 
-/* reliable write to opened file descriptor (retries, if necessary, until hard error) */
+/** reliable write to opened file descriptor (retries, if necessary, until hard error) */
 ssize_t redset_write(const char* file, int fd, const void* buf, size_t size);
 
-/* make a good attempt to read from file (retries, if necessary, return error if fail) */
+/** make a good attempt to read from file (retries, if necessary, return error if fail) */
 ssize_t redset_read_attempt(const char* file, int fd, void* buf, size_t size);
 
-/* make a good attempt to write to file (retries, if necessary, return error if fail) */
+/** make a good attempt to write to file (retries, if necessary, return error if fail) */
 ssize_t redset_write_attempt(const char* file, int fd, const void* buf, size_t size);
 
-/* read line from file into buf with given size */
+/** read line from file into buf with given size */
 ssize_t redset_read_line(const char* file, int fd, char* buf, size_t size);
 
-/* write a formatted string to specified file descriptor */
+/** write a formatted string to specified file descriptor */
 ssize_t redset_writef(const char* file, int fd, const char* format, ...);
 
-/* logically concatenate n opened files and read count bytes from this logical file into buf starting
+/** logically concatenate n opened files and read count bytes from this logical file into buf starting
  * from offset, pad with zero on end if missing data */
 int redset_read_pad_n(
   int n,
@@ -71,7 +73,7 @@ int redset_read_pad_n(
   unsigned long* filesizes
 );
 
-/* write to an array of open files with known filesizes and treat them as one single large file */
+/** write to an array of open files with known filesizes and treat them as one single large file */
 int redset_write_pad_n(
   int n,
   const char** files,
@@ -82,44 +84,42 @@ int redset_write_pad_n(
   unsigned long* filesizes
 );
 
-/* given a filename, return number of bytes in file */
+/** given a filename, return number of bytes in file */
 unsigned long redset_file_size(const char* file);
 
-/* tests whether the file or directory exists */
+/** tests whether the file or directory exists */
 int redset_file_exists(const char* file);
 
-/* tests whether the file or directory is readable */
+/** tests whether the file or directory is readable */
 int redset_file_is_readable(const char* file);
 
-/* tests whether the file or directory is writeable */
+/** tests whether the file or directory is writeable */
 int redset_file_is_writeable(const char* file);
 
-/* delete a file */
+/** delete a file */
 int redset_file_unlink(const char* file);
 
-/* opens, reads, and computes the crc32 value for the given filename */
+/** opens, reads, and computes the crc32 value for the given filename */
 int redset_crc32(const char* filename, uLong* crc);
+///@}
 
-/*
-=========================================
-Directory functions
-=========================================
-*/
+/********************************************************/
+/** \name Directory functions */
+///@{
 
-/* recursively create directory and subdirectories */
+/** recursively create directory and subdirectories */
 int redset_mkdir(const char* dir, mode_t mode);
 
-/* remove directory */
+/** remove directory */
 int redset_rmdir(const char* dir);
 
-/* write current working directory to buf */
+/** write current working directory to buf */
 int redset_getcwd(char* buf, size_t size);
+///@}
 
-/*
-=========================================
-File Copy Functions
-=========================================
-*/
+/********************************************************/
+/** \name File Copy Functions */
+///@{
 
 int redset_file_copy(
   const char* src_file,
@@ -127,23 +127,23 @@ int redset_file_copy(
   unsigned long buf_size,
   uLong* crc
 );
+///@}
 
-/*
-=========================================
-File compression functions
-=========================================
-*/
+/********************************************************/
+/** \name File compression functions */
+///@{
 
-/* compress the specified file using blocks of size block_size and store as file_dst */
+/** compress the specified file using blocks of size block_size and store as file_dst */
 int redset_compress_in_place(const char* file_src, const char* file_dst, unsigned long block_size, int level);
 
-/* uncompress the specified file and store as file_dst */
+/** uncompress the specified file and store as file_dst */
 int redset_uncompress_in_place(const char* file_src, const char* file_dst);
 
-/* compress the specified file using blocks of size block_size and store as file_dst */
+/** compress the specified file using blocks of size block_size and store as file_dst */
 int redset_compress(const char* file_src, const char* file_dst, unsigned long block_size, int level);
 
-/* uncompress the specified file and store as file_dst */
+/** uncompress the specified file and store as file_dst */
 int redset_uncompress(const char* file_src, const char* file_dst);
+///@}
 
 #endif

--- a/src/redset_util.h
+++ b/src/redset_util.h
@@ -14,34 +14,38 @@ extern char* redset_hostname;
 extern int redset_mpi_buf_size;
 extern size_t redset_page_size;
 
-/* print error message to stdout */
+/** \file redset_util.h
+ *  \ingroup redset
+ *  \brief utilities for redundancy sets */
+
+/** print error message to stdout */
 void redset_err(const char *fmt, ...);
 
-/* print warning message to stdout */
+/** print warning message to stdout */
 void redset_warn(const char *fmt, ...);
 
-/* print message to stdout if redset_debug is set and it is >= level */
+/** print message to stdout if redset_debug is set and it is >= level */
 void redset_dbg(int level, const char *fmt, ...);
 
-/* print abort message and kill run */
+/** print abort message and kill run */
 void redset_abort(int rc, const char *fmt, ...);
 
-/* allocate size bytes, returns NULL if size == 0,
+/** allocate size bytes, returns NULL if size == 0,
  * calls redset_abort if allocation fails */
 #define REDSET_MALLOC(X) redset_malloc(X, __FILE__, __LINE__);
 void* redset_malloc(size_t size, const char* file, int line);
 
-/* pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
+/** pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
 void redset_free(void* ptr);
 
-/* allocates a block of memory and aligns it to specified alignment */
+/** allocates a block of memory and aligns it to specified alignment */
 void* redset_align_malloc(size_t size, size_t align);
 
-/* frees a blocked allocated with a call to redset_align_malloc */
+/** frees a blocked allocated with a call to redset_align_malloc */
 void redset_align_free(void* buf);
 
-/* sends a NUL-terminated string to a process,
- * allocates space and recieves a NUL-terminated string from a process,
+/** sends a NUL-terminated string to a process,
+ * allocates space and recieves a NULL-terminated string from a process,
  * can specify MPI_PROC_NULL as either send or recv rank */
 int redset_str_sendrecv(
   const char* send_str, int send_rank,
@@ -49,7 +53,7 @@ int redset_str_sendrecv(
   MPI_Comm comm
 );
 
-/* returns true (non-zero) if flag on each process in comm is true */
+/** returns true (non-zero) if flag on each process in comm is true */
 int redset_alltrue(int flag, MPI_Comm comm);
 
 #endif


### PR DESCRIPTION
Re-formatted the comments in the `.h` files to allow doxygen parsing for [generated documentation](https://ecp-veloc.github.io/component-user-docs/).