### PR TITLE
Apple’s sys/stat.h stat struct

### DIFF
--- a/src/redset.c
+++ b/src/redset.c
@@ -2,8 +2,11 @@
 #define _GNU_SOURCE
 
 /* TODO: ugly hack until we get a configure test */
-// HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC
+#if defined(__APPLE__)
+#define HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC 1
+#else
 #define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+#endif
 // HAVE_STRUCT_STAT_ST_MTIME_N
 // HAVE_STRUCT_STAT_ST_UMTIME
 // HAVE_STRUCT_STAT_ST_MTIME_USEC

--- a/src/redset.c
+++ b/src/redset.c
@@ -241,7 +241,7 @@ static int redset_create_xor(MPI_Comm parent_comm, redset_base* d)
   }
 
   /* record group mapping info in descriptor */
-  state->group_map = header; 
+  state->group_map = header;
 
   /* record group rank, world rank, and hostname of left and right partners */
   redset_set_partners(
@@ -463,7 +463,7 @@ static int redset_split_across(
   /* Split procs in parent into groups containing all procs with same
    * rank within group, order by rank in parent */
   MPI_Comm_split(comm_parent, rank_group, rank_parent, comm_across);
-  
+
   return REDSET_SUCCESS;
 }
 
@@ -1335,7 +1335,7 @@ int redset_unapply(
 
 static int redset_from_dir(
   MPI_Comm comm_world,
-  const char* name, 
+  const char* name,
   redset_base* d)
 {
   /* get name of this process */


### PR DESCRIPTION
@adammoody This fixes your hack just for apple machines. I’m not sure where the other stat structs may appear.

(Same in shuffile).