### PR TITLE
Replicas

### DIFF
--- a/src/redset.c
+++ b/src/redset.c
@@ -966,7 +966,7 @@ static int redset_encode_reddesc(
     break;
   }
 
-  /* sort the header to be list items alphabetically,
+  /* sort the header to list items alphabetically,
    * this isn't strictly required, but it ensures the kvtrees
    * are stored in the same byte order so that we can reproduce
    * the redundancy file identically on a rebuild */

--- a/src/redset.c
+++ b/src/redset.c
@@ -431,13 +431,13 @@ static int redset_create_base(
   case REDSET_COPY_SINGLE:
     break;
   case REDSET_COPY_PARTNER:
-    redset_create_partner(comm, d, k);
+    redset_construct_partner(comm, d, k);
     break;
   case REDSET_COPY_XOR:
-    redset_create_xor(comm, d);
+    redset_construct_xor(comm, d);
     break;
   case REDSET_COPY_RS:
-    redset_create_rs(comm, d, k);
+    redset_construct_rs(comm, d, k);
     break;
   }
 
@@ -467,19 +467,19 @@ int redset_create(
 }
 
 /* build a redundancy descriptor for SINGLE encoding */
-int redset_new_single(
+int redset_create_single(
   MPI_Comm comm,
   const char* group_name,
   redset* dvp)
 {
   int set_size = 8;
-  int k = 2;
+  int k = 1;
   int rc = redset_create_base(REDSET_COPY_SINGLE, comm, group_name, set_size, k, dvp);
   return rc;
 }
 
 /* build a redundancy descriptor for PARTNER encoding */
-int redset_new_partner(
+int redset_create_partner(
   MPI_Comm comm,
   const char* group_name,
   int replicas,
@@ -491,7 +491,7 @@ int redset_new_partner(
 }
 
 /* build a redundancy descriptor for XOR encoding */
-int redset_new_xor(
+int redset_create_xor(
   MPI_Comm comm,
   const char* group_name,
   int set_size,
@@ -503,7 +503,7 @@ int redset_new_xor(
 }
 
 /* build a redundancy descriptor for Reed-Solomon encoding */
-int redset_new_rs(
+int redset_create_rs(
   MPI_Comm comm,
   const char* group_name,
   int set_size,
@@ -644,15 +644,15 @@ int redset_restore_from_kvtree(
     break;
   case REDSET_COPY_PARTNER:
     redset_read_from_kvtree_partner(hash, &partner_replicas);
-    redset_create_partner(comm, d, partner_replicas);
+    redset_construct_partner(comm, d, partner_replicas);
     break;
   case REDSET_COPY_XOR:
-    redset_create_xor(comm, d);
+    redset_construct_xor(comm, d);
     break;
   case REDSET_COPY_RS:
     /* read number of encoding blocks from hash to pass to create call */
     redset_read_from_kvtree_rs(hash, &rs_encoding);
-    redset_create_rs(comm, d, rs_encoding);
+    redset_construct_rs(comm, d, rs_encoding);
     break;
   }
 

--- a/src/redset.c
+++ b/src/redset.c
@@ -456,7 +456,12 @@ int redset_create(
   redset* dvp)
 {
   int set_size = 8;
-  int k = 2;
+
+  int k = 1;
+  if (type == REDSET_COPY_RS) {
+    k = 2;
+  }
+
   int rc = redset_create_base(type, comm, group_name, set_size, k, dvp);
   return rc;
 }

--- a/src/redset.h
+++ b/src/redset.h
@@ -54,14 +54,14 @@ int redset_create(
 );
 
 /** create a new redundancy set descriptor for SINGLE encoding */
-int redset_new_single(
+int redset_create_single(
   MPI_Comm comm,     /**< [IN]  - process group participating in set */
   const char* group, /**< [IN]  - string specifying procs in the same failure group */
   redset* d          /**< [OUT] - output redundancy descriptor */
 );
 
 /** create a new redundancy set descriptor for PARTNER encoding */
-int redset_new_partner(
+int redset_create_partner(
   MPI_Comm comm,     /**< [IN]  - process group participating in set */
   const char* group, /**< [IN]  - string specifying procs in the same failure group */
   int replicas,      /**< [IN]  - number of partner replicas */
@@ -69,7 +69,7 @@ int redset_new_partner(
 );
 
 /** create a new redundancy set descriptor for XOR encoding */
-int redset_new_xor(
+int redset_create_xor(
   MPI_Comm comm,     /**< [IN]  - process group participating in set */
   const char* group, /**< [IN]  - string specifying procs in the same failure group */
   int size,          /**< [IN]  - minimum number of ranks for a redundancy set */
@@ -77,7 +77,7 @@ int redset_new_xor(
 );
 
 /** create a new redundancy set descriptor for ReedSolomon encoding */
-int redset_new_rs(
+int redset_create_rs(
   MPI_Comm comm,     /**< [IN]  - process group participating in set */
   const char* group, /**< [IN]  - string specifying procs in the same failure group */
   int size,          /**< [IN]  - minimum number of ranks for a redundancy set */

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -23,6 +23,7 @@ typedef struct {
   int       rhs_rank;       /* rank which is one more (with wrap to lowest) within set */
   int       rhs_rank_world; /* rank of rhs process in comm world */
   char*     rhs_hostname;   /* hostname of rhs process */
+  int       replicas;       /* number of partner replicas */
 } redset_partner;
 
 typedef struct {
@@ -88,7 +89,8 @@ int redset_meta_apply(const char* file, const kvtree* meta);
 
 int redset_create_partner(
   MPI_Comm parent_comm,
-  redset_base* d
+  redset_base* d,
+  int replicas
 );
 
 int redset_create_xor(
@@ -112,6 +114,16 @@ int redset_delete_xor(
 
 int redset_delete_rs(
   redset_base* d
+);
+
+int redset_store_to_kvtree_partner(
+  const redset_base* d,
+  kvtree* hash
+);
+
+int redset_read_from_kvtree_partner(
+  const kvtree* hash,
+  int* outreplicas
 );
 
 int redset_store_to_kvtree_rs(

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -87,18 +87,18 @@ int redset_meta_encode(const char* file, kvtree* meta);
 /* apply file metadata in meta to file */
 int redset_meta_apply(const char* file, const kvtree* meta);
 
-int redset_create_partner(
+int redset_construct_partner(
   MPI_Comm parent_comm,
   redset_base* d,
   int replicas
 );
 
-int redset_create_xor(
+int redset_construct_xor(
   MPI_Comm parent_comm,
   redset_base* d
 );
 
-int redset_create_rs(
+int redset_construct_rs(
   MPI_Comm parent_comm,
   redset_base* d,
   int encoding

--- a/src/redset_partner.c
+++ b/src/redset_partner.c
@@ -59,7 +59,7 @@ static int redset_read_partner_file(
 
 /* given a redundancy descriptor with all top level fields filled in
  * allocate and fill in structure for partner specific fields in state */
-int redset_create_partner(MPI_Comm parent_comm, redset_base* d, int replicas)
+int redset_construct_partner(MPI_Comm parent_comm, redset_base* d, int replicas)
 {
   int rc = REDSET_SUCCESS;
 

--- a/src/redset_partner.c
+++ b/src/redset_partner.c
@@ -222,6 +222,12 @@ int redset_apply_partner(
     );
   }
 
+  /* sort the header to list items alphabetically,
+   * this isn't strictly required, but it ensures the kvtrees
+   * are stored in the same byte order so that we can reproduce
+   * the redundancy file identically on a rebuild */
+  redset_sort_kvtree(header);
+
   /* write out the partner header */
   kvtree_write_fd(partner_file, fd_partner, header);
   kvtree_delete(&header);
@@ -502,6 +508,12 @@ int redset_recover_partner_rebuild(
         partner_file, errno, strerror(errno), __FILE__, __LINE__
       );
     }
+
+    /* sort the header to list items alphabetically,
+     * this isn't strictly required, but it ensures the kvtrees
+     * are stored in the same byte order so that we can reproduce
+     * the redundancy file identically on a rebuild */
+    redset_sort_kvtree(header);
 
     /* write partner file header */
     kvtree_write_fd(partner_file, fd_partner, header);

--- a/src/redset_reedsolomon.c
+++ b/src/redset_reedsolomon.c
@@ -750,7 +750,7 @@ static unsigned int* build_vandermonde(redset_reedsolomon* state, int n, int k)
 
 /* given a redundancy descriptor with all top level fields filled in
  * allocate and fill in structure for Reed-Solomon specific fields in state */
-int redset_create_rs(MPI_Comm parent_comm, redset_base* d, int encoding)
+int redset_construct_rs(MPI_Comm parent_comm, redset_base* d, int encoding)
 {
   int rc = REDSET_SUCCESS;
 

--- a/src/redset_reedsolomon.c
+++ b/src/redset_reedsolomon.c
@@ -17,9 +17,6 @@
 #include "redset.h"
 #include "redset_internal.h"
 
-#define REDSET_KEY_COPY_RS_FILES "FILES"
-#define REDSET_KEY_COPY_RS_FILE  "FILE"
-#define REDSET_KEY_COPY_RS_SIZE  "SIZE"
 #define REDSET_KEY_COPY_RS_CHUNK "CHUNK"
 #define REDSET_KEY_COPY_RS_CKSUM "CKSUM"
 
@@ -55,15 +52,15 @@ static int redset_read_rs_file(
     redset_dbg(2, "Do not have read access to file: %s @ %s:%d",
       file, __FILE__, __LINE__
     );
-    return 0;
+    return REDSET_FAILURE;
   }
 
   /* read header info from file */
   if (kvtree_read_file(file, header) != KVTREE_SUCCESS) {
-    return 0;
+    return REDSET_FAILURE;
   }
 
-  return 1;
+  return REDSET_SUCCESS;
 }
 
 /* multiply v1 * v2 in GF(2^m) arithmetic given the generating polynomial in poly */
@@ -1090,47 +1087,22 @@ int redset_apply_rs(
   unsigned char** send_bufs = (unsigned char**) redset_buffers_alloc(1, redset_mpi_buf_size);
   unsigned char* send_buf = send_bufs[0];
 
-  /* allocate space in structures for each file */
-  int* fds                 = (int*)           REDSET_MALLOC(num_files * sizeof(int));
-  const char** filenames   = (const char**)   REDSET_MALLOC(num_files * sizeof(char*));
-  unsigned long* filesizes = (unsigned long*) REDSET_MALLOC(num_files * sizeof(unsigned long));
-
   /* allocate a structure to record meta data about our files and redundancy descriptor */
   kvtree* current_hash = kvtree_new();
 
-  /* record total number of files we have */
-  kvtree_set_kv_int(current_hash, REDSET_KEY_COPY_RS_FILES, num_files);
+  /* encode file info into hash */
+  redset_file_encode_kvtree(current_hash, num_files, files);
 
-  /* enter index, name, and size of each file */
-  unsigned long my_bytes = 0;
-  kvtree* files_hash = kvtree_set(current_hash, "FILE", kvtree_new());
-  for (i = 0; i < num_files; i++) {
-    /* get file name of this file */
-    const char* file_name = files[i];
-
-    /* get file size of this file */
-    unsigned long file_size = redset_file_size(file_name);
-    my_bytes += file_size;
-
-    /* add entry for this file, including its index, name, and size */
-    kvtree* file_hash = kvtree_setf(files_hash, kvtree_new(), "%d %s", i, file_name);
-
-    /* record file meta data of this file */
-    redset_meta_encode(file_name, file_hash);
-
-    /* record entry in our names and sizes arrays */
-    filenames[i] = file_name;
-    filesizes[i] = file_size;
-
-    /* open the file */
-    fds[i] = redset_open(file_name, O_RDONLY);
-    if (fds[i] < 0) {
-      /* TODO: try again? */
-      redset_abort(-1, "Opening file for encoding: redset_open(%s, O_RDONLY) errno=%d %s @ %s:%d",
-        file_name, errno, strerror(errno), __FILE__, __LINE__
-      );
-    }
+  /* open logical file for reading */
+  redset_file rsf;
+  if (redset_file_open(current_hash, O_RDONLY, (mode_t)0, &rsf) != REDSET_SUCCESS) {
+    redset_abort(-1, "Opening data files for reading for encoding @ %s:%d",
+      __FILE__, __LINE__
+    );
   }
+
+  /* get size of our logical file */
+  unsigned long my_bytes = redset_file_bytes(&rsf);
 
   /* store our redundancy descriptor in hash */
   kvtree* desc_hash = kvtree_new();
@@ -1241,8 +1213,7 @@ int redset_apply_rs(
       unsigned long offset = chunk_size * (unsigned long) chunk_id_rel + nread;
 
       /* read data from our file into send buffer */
-      if (redset_read_pad_n(num_files, filenames, fds,
-          send_buf, count, offset, filesizes) != REDSET_SUCCESS)
+      if (redset_file_pread(&rsf, send_buf, count, offset) != REDSET_SUCCESS)
       {
         /* read failed, make sure we fail this rebuild */
         rc = REDSET_FAILURE;
@@ -1303,8 +1274,8 @@ int redset_apply_rs(
   }
 
   /* close my dataset files */
-  for (i=0; i < num_files; i++) {
-    redset_close(filenames[i], fds[i]);
+  if (redset_file_close(&rsf) != REDSET_SUCCESS) {
+    rc = REDSET_FAILURE;
   }
 
   redset_free(&request);
@@ -1314,11 +1285,6 @@ int redset_apply_rs(
   redset_buffers_free(state->encoding, &data_bufs);
   redset_buffers_free(state->encoding, &recv_bufs);
   redset_buffers_free(1,               &send_bufs);
-
-  /* free the buffers */
-  redset_free(&filesizes);
-  redset_free(&filenames);
-  redset_free(&fds);
 
 #if 0
   /* if crc_on_copy is set, compute and store CRC32 value for chunk file */
@@ -1389,10 +1355,8 @@ int redset_recover_rs_rebuild(
   int i;
   int j;
 
+  redset_file rsf;
   int fd_chunk = -1;
-  int* fds = NULL;
-  const char** filenames = NULL;
-  unsigned long* filesizes = NULL;
 
   /* get pointer to RS state structure */
   redset_reedsolomon* state = (redset_reedsolomon*) d->state;
@@ -1420,7 +1384,6 @@ int redset_recover_rs_rebuild(
   off_t header_size = 0;
 
   /* exchange headers and open each of our files for reading or writing */
-  int num_files = -1;
   kvtree* current_hash = NULL;
   kvtree* send_hash = NULL;
   kvtree* recv_hash = NULL;
@@ -1444,51 +1407,10 @@ int redset_recover_rs_rebuild(
     current_hash = kvtree_getf(header, "%d", d->rank);
 
     /* lookup number of files this process wrote */
-    if (kvtree_util_get_int(current_hash, REDSET_KEY_COPY_RS_FILES, &num_files) != REDSET_SUCCESS) {
-      redset_abort(-1, "Failed to read number of files from redundancy file header: %s @ %s:%d",
-        chunk_file, __FILE__, __LINE__
+    if (redset_file_open(current_hash, O_RDONLY, (mode_t)0, &rsf) != REDSET_SUCCESS) {
+      redset_abort(-1, "Failed to open data files for reading during rebuild @ %s:%d",
+        __FILE__, __LINE__
       );
-    }
-
-    /* allocate arrays to hold file descriptors, filenames, and filesizes for each of our files */
-    fds       = (int*)           REDSET_MALLOC(num_files * sizeof(int));
-    filenames = (const char**)   REDSET_MALLOC(num_files * sizeof(char*));
-    filesizes = (unsigned long*) REDSET_MALLOC(num_files * sizeof(unsigned long));
-
-    /* open each of our files */
-    kvtree* files_hash = kvtree_get(current_hash, "FILE");
-    for (i = 0; i < num_files; i++) {
-      /* get file name of this file */
-      kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
-      kvtree_elem* elem = kvtree_elem_first(index_hash);
-      const char* file_name = kvtree_elem_key(elem);
-  
-      /* lookup hash for this file */
-      kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
-
-      /* copy the full filename */
-      filenames[i] = file_name;
-      if (filenames[i] == NULL) {
-        redset_abort(-1, "Failed to copy filename during rebuild @ %s:%d",
-          file_name, __FILE__, __LINE__
-        );
-      }
-
-      /* lookup the filesize */
-      if (kvtree_util_get_bytecount(file_hash, "SIZE", &filesizes[i]) != REDSET_SUCCESS) {
-        redset_abort(-1, "Failed to read file size for file %s in redundancy file header during rebuild @ %s:%d",
-          file_name, __FILE__, __LINE__
-        );
-      }
-
-      /* open the file for reading */
-      fds[i] = redset_open(file_name, O_RDONLY);
-      if (fds[i] < 0) {
-        /* TODO: try again? */
-        redset_abort(-1, "Opening file for reading in rebuild: redset_open(%s, O_RDONLY) errno=%d %s @ %s:%d",
-          file_name, errno, strerror(errno), __FILE__, __LINE__
-        );
-      }
     }
 
     /* if failed rank is to my left, i have its file info, send it the header */
@@ -1546,55 +1468,14 @@ int redset_recover_rs_rebuild(
       kvtree_unset(header, rankstr);
     }
 
-    /* get the number of files that we need to rebuild */
-    if (kvtree_util_get_int(current_hash, REDSET_KEY_COPY_RS_FILES, &num_files) != REDSET_SUCCESS) {
-      redset_abort(-1, "Failed to read number of files from redundancy file header during rebuild @ %s:%d",
-        __FILE__, __LINE__
-      );
-    }
-
-    /* allocate items for each file */
-    fds       = (int*)           REDSET_MALLOC(num_files * sizeof(int));
-    filenames = (const char**)   REDSET_MALLOC(num_files * sizeof(char*));
-    filesizes = (unsigned long*) REDSET_MALLOC(num_files * sizeof(unsigned long));
-
     /* get permissions for file */
     mode_t mode_file = redset_getmode(1, 1, 0);
 
-    /* open each of our files */
-    kvtree* files_hash = kvtree_get(current_hash, "FILE");
-    for (i = 0; i < num_files; i++) {
-      /* get file name of this file */
-      kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
-      kvtree_elem* elem = kvtree_elem_first(index_hash);
-      const char* file_name = kvtree_elem_key(elem);
-  
-      /* lookup hash for this file */
-      kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
-
-      /* copy the full filename */
-      filenames[i] = file_name;
-      if (filenames[i] == NULL) {
-        redset_abort(-1, "Failed to copy filename during rebuild @ %s:%d",
-          file_name, __FILE__, __LINE__
-        );
-      }
-
-      /* lookup the filesize */
-      if (kvtree_util_get_bytecount(file_hash, "SIZE", &filesizes[i]) != REDSET_SUCCESS) {
-        redset_abort(-1, "Failed to read file size for file %s in redundancy file header during rebuild @ %s:%d",
-          file_name, __FILE__, __LINE__
-        );
-      }
-
-      /* open my file for writing */
-      fds[i] = redset_open(filenames[i], O_WRONLY | O_CREAT | O_TRUNC, mode_file);
-      if (fds[i] < 0) {
-        /* TODO: try again? */
-        redset_abort(-1, "Opening file for writing in rebuild: redset_open(%s) errno=%d %s @ %s:%d",
-          filenames[i], errno, strerror(errno), __FILE__, __LINE__
-        );
-      }
+    /* get the number of files that we need to rebuild */
+    if (redset_file_open(current_hash, O_WRONLY | O_CREAT | O_TRUNC, mode_file, &rsf) != REDSET_SUCCESS) {
+      redset_abort(-1, "Failed to open data files for writing during rebuild @ %s:%d",
+        __FILE__, __LINE__
+      );
     }
 
     /* open my redundancy file for writing */
@@ -1747,8 +1628,7 @@ int redset_recover_rs_rebuild(
           unsigned long offset = chunk_size * (unsigned long) chunk_id_rel + nread;
 
           /* read data from our file */
-          if (redset_read_pad_n(num_files, filenames, fds,
-              send_bufs[0], count, offset, filesizes) != REDSET_SUCCESS)
+          if (redset_file_pread(&rsf, send_bufs[0], count, offset) != REDSET_SUCCESS)
           {
             /* read failed, make sure we fail this rebuild */
             rc = REDSET_FAILURE;
@@ -1831,8 +1711,7 @@ int redset_recover_rs_rebuild(
           /* for this chunk, write data to the logical file */
           int chunk_id_rel = get_data_id(d->ranks, state->encoding, d->rank, received_chunk_id);
           unsigned long offset = chunk_size * (unsigned long) chunk_id_rel + nread;
-          if (redset_write_pad_n(num_files, filenames, fds,
-            recv_bufs[lhs_rank], count, offset, filesizes) != REDSET_SUCCESS)
+          if (redset_file_pwrite(&rsf, recv_bufs[lhs_rank], count, offset) != REDSET_SUCCESS)
           {
             /* write failed, make sure we fail this rebuild */
             rc = REDSET_FAILURE;
@@ -1868,10 +1747,8 @@ int redset_recover_rs_rebuild(
   }
 
   /* close my checkpoint files */
-  for (i=0; i < num_files; i++) {
-    if (redset_close(filenames[i], fds[i]) != REDSET_SUCCESS) {
-      rc = REDSET_FAILURE;
-    }
+  if (redset_file_close(&rsf) != REDSET_SUCCESS) {
+    rc = REDSET_FAILURE;
   }
 
 #if 0
@@ -1910,20 +1787,7 @@ int redset_recover_rs_rebuild(
 
   /* reapply metadata properties to file: uid, gid, mode bits, timestamps */
   if (need_rebuild) {
-    /* we've written data for all files */
-    kvtree* files_hash = kvtree_get(current_hash, "FILE");
-    for (i = 0; i < num_files; i++) {
-      /* get file name of this file */
-      kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
-      kvtree_elem* elem = kvtree_elem_first(index_hash);
-      const char* file_name = kvtree_elem_key(elem);
-  
-      /* lookup hash for this file */
-      kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
-
-      /* set metadata properties on rebuilt file */
-      redset_meta_apply(file_name, file_hash);
-    }
+    redset_file_apply_meta(current_hash);
   }
 
   /* free buffers */
@@ -1932,9 +1796,6 @@ int redset_recover_rs_rebuild(
   redset_buffers_free(d->ranks, &recv_bufs);
 
   /* free the buffers */
-  redset_free(&filesizes);
-  redset_free(&filenames);
-  redset_free(&fds);
   kvtree_delete(&header);
 
   return rc;
@@ -1946,85 +1807,28 @@ int redset_recover_rs(
   const char* name,
   const redset_base* d)
 {
-  int i;
   MPI_Comm comm_world = d->parent_comm;
 
   /* get pointer to RS state structure */
   redset_reedsolomon* state = (redset_reedsolomon*) d->state;
 
-  /* set chunk filenames of form: rs.<group_id>_<set_rank+1>_of_<set_ranks>.redset */
-  char chunk_file[REDSET_MAX_FILENAME];
-  redset_build_rs_filename(name, d, chunk_file, sizeof(chunk_file));
-
   /* assume we have our files */
-  int have_my_files = 1;
+  int need_rebuild = 0;
 
   /* check whether we have our chunk file */
   kvtree* header = kvtree_new();
-  if (redset_read_rs_file(name, d, header)) {
+  if (redset_read_rs_file(name, d, header) == REDSET_SUCCESS) {
     /* got our chunk file, see if we have each data file */
     kvtree* current_hash = kvtree_getf(header, "%d", d->rank);
-
-    /* lookup number of files this process wrote */
-    int numfiles;
-    if (kvtree_util_get_int(current_hash, REDSET_KEY_COPY_RS_FILES, &numfiles) != REDSET_SUCCESS) {
-      redset_abort(-1, "Failed to read number of files from redundancy file header: %s @ %s:%d",
-        chunk_file, __FILE__, __LINE__
-      );
-    }
-
-    /* check that each of our data files exists and is the correct size */
-    kvtree* files_hash = kvtree_get(current_hash, "FILE");
-    for (i = 0; i < numfiles; i++) {
-      /* get file name of this file */
-      kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
-      kvtree_elem* elem = kvtree_elem_first(index_hash);
-      const char* file_name = kvtree_elem_key(elem);
-  
-      /* lookup hash for this file */
-      kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
-      if (file_hash == NULL) {
-        /* failed to find file name recorded */
-        have_my_files = 0;
-        continue;
-      }
-  
-      /* check that file exists */
-      if (redset_file_exists(file_name) != REDSET_SUCCESS) {
-        /* failed to find file */
-        have_my_files = 0;
-        continue;
-      }
-  
-      /* get file size of this file */
-      unsigned long file_size = redset_file_size(file_name);
-  
-      /* lookup expected file size and compare to actual size */
-      unsigned long file_size_saved;
-      if (kvtree_util_get_bytecount(file_hash, "SIZE", &file_size_saved) == KVTREE_SUCCESS) {
-        if (file_size != file_size_saved) {
-          /* file size does not match */
-          have_my_files = 0;
-          continue;
-        }
-      } else {
-        /* file size not recorded */
-        have_my_files = 0;
-        continue;
-      }
+    if (redset_file_check(current_hash) != REDSET_SUCCESS) {
+      /* some data file is bad */
+      need_rebuild = 1;
     }
   } else {
     /* missing our chunk file */
-    have_my_files = 0;
+    need_rebuild = 1;
   }
-
   kvtree_delete(&header);
-
-  /* check whether I have my full checkpoint file, assume I don't */
-  int need_rebuild = 1;
-  if (have_my_files) {
-    need_rebuild = 0;
-  }
 
   /* count how many in my set need to rebuild */
   int total_rebuild;
@@ -2047,6 +1851,7 @@ int redset_recover_rs(
     MPI_Allgather(&tmp_rank, 1, MPI_INT, rebuild_ranks, 1, MPI_INT, d->comm);
 
     /* slide ranks that need to be rebuilt to front of the array */
+    int i;
     int slot = 0;
     for (i = 0; i < d->ranks; i++) {
       if (rebuild_ranks[i] != -1) {

--- a/src/redset_reedsolomon.c
+++ b/src/redset_reedsolomon.c
@@ -1216,7 +1216,7 @@ int redset_apply_rs(
     );
   }
 
-  /* sort the header to be list items alphabetically,
+  /* sort the header to list items alphabetically,
    * this isn't strictly required, but it ensures the kvtrees
    * are stored in the same byte order so that we can reproduce
    * the redundancy file identically on a rebuild */
@@ -1670,7 +1670,7 @@ int redset_recover_rs_rebuild(
       kvtree_set(header, rank_key, partner_hash);
     }
 
-    /* sort the header to be list items alphabetically,
+    /* sort the header to list items alphabetically,
      * this isn't strictly required, but it ensures the kvtrees
      * are stored in the same byte order so that we can reproduce
      * the redundancy file identically on a rebuild */

--- a/src/redset_single.c
+++ b/src/redset_single.c
@@ -90,13 +90,9 @@ int redset_apply_single(
   /* encode file info into hash */
   redset_file_encode_kvtree(current_hash, numfiles, files);
 
-  /* use our global rank for single */
-  int rank;
-  MPI_Comm_rank(comm_world, &rank);
-
   /* copy meta data to hash */
   kvtree* meta_hash = kvtree_new();
-  kvtree_setf(meta_hash, current_hash, "%d", rank);
+  kvtree_setf(meta_hash, current_hash, "%d", d->rank);
 
   /* sort the header to list items alphabetically,
    * this isn't strictly required, but it ensures the kvtrees
@@ -129,12 +125,8 @@ int redset_recover_single(
   /* check whether we have our files */
   kvtree* header = kvtree_new();
   if (redset_read_single_file(name, d, header) == REDSET_SUCCESS) {
-    /* use our global rank for single */
-    int rank;
-    MPI_Comm_rank(comm_world, &rank);
-
     /* get pointer to hash for this rank */
-    kvtree* current_hash = kvtree_getf(header, "%d", rank);
+    kvtree* current_hash = kvtree_getf(header, "%d", d->rank);
     if (redset_file_check(current_hash) != REDSET_SUCCESS) {
       /* some data file is bad */
       have_my_files = 0;

--- a/src/redset_single.c
+++ b/src/redset_single.c
@@ -96,6 +96,12 @@ int redset_apply_single(
   kvtree* meta_hash = kvtree_new();
   kvtree_setf(meta_hash, current_hash, "%d", rank_world);
 
+  /* sort the header to list items alphabetically,
+   * this isn't strictly required, but it ensures the kvtrees
+   * are stored in the same byte order so that we can reproduce
+   * the redundancy file identically on a rebuild */
+  redset_sort_kvtree(meta_hash);
+
   /* write meta data to file in directory */
   char filename[REDSET_MAX_FILENAME];
   redset_build_single_filename(name, d, filename, sizeof(filename));

--- a/src/redset_single.c
+++ b/src/redset_single.c
@@ -30,7 +30,7 @@
  * are checked against the specified files.
  */
 
-/* set partner filename */
+/* set single filename */
 static void redset_build_single_filename(
   const char* name,
   const redset_base* d,
@@ -38,6 +38,32 @@ static void redset_build_single_filename(
   size_t len)
 {
   snprintf(file, len, "%s.single.redset", name);
+}
+
+/* returns 1 if we successfully read redundancy file, 0 otherwise */
+static int redset_read_single_file(
+  const char* name,
+  const redset_base* d,
+  kvtree* header)
+{
+  /* get single filename */
+  char file[REDSET_MAX_FILENAME];
+  redset_build_single_filename(name, d, file, sizeof(file));
+
+  /* check that we can read the file */
+  if (redset_file_is_readable(file) != REDSET_SUCCESS) {
+    redset_dbg(2, "Do not have read access to file: %s @ %s:%d",
+      file, __FILE__, __LINE__
+    );
+    return REDSET_FAILURE;
+  }
+
+  /* read header from file */
+  if (kvtree_read_file(file, header) != KVTREE_SUCCESS) {
+    return REDSET_FAILURE;
+  }
+
+  return REDSET_SUCCESS;
 }
 
 int redset_encode_reddesc_single(
@@ -58,43 +84,19 @@ int redset_apply_single(
   int i;
   MPI_Comm comm_world = d->parent_comm;
 
-  /* get name of this process */
-  int rank_world;
-  MPI_Comm_rank(comm_world, &rank_world);
-
   /* allocate a structure to record meta data about our files and redundancy descriptor */
   kvtree* current_hash = kvtree_new();
 
-  /* record total number of files we have */
-  kvtree_set_kv_int(current_hash, "FILES", numfiles);
+  /* encode file info into hash */
+  redset_file_encode_kvtree(current_hash, numfiles, files);
 
-  /* step through each of my files for the specified dataset
-   * to scan for any incomplete files */
-  /* enter index, name, and size of each file */
-  double my_bytes = 0.0;
-  kvtree* files_hash = kvtree_set(current_hash, "FILE", kvtree_new());
-  for (i = 0; i < numfiles; i++) {
-    /* get file name of this file */
-    const char* file_name = files[i];
-
-    /* get file size of this file */
-    unsigned long file_size = redset_file_size(file_name);
-
-    /* add up the number of bytes on our way through */
-    my_bytes += (double) file_size;
-
-    /* add entry for this file, including its index and name */
-    kvtree* file_hash = kvtree_setf(files_hash, kvtree_new(), "%d %s", i, file_name);
-
-    /* record file permissions, timestamps, size */
-    redset_meta_encode(file_name, file_hash);
-
-    /* TODO: compute and store CRC values */
-  }
+  /* use our global rank for single */
+  int rank;
+  MPI_Comm_rank(comm_world, &rank);
 
   /* copy meta data to hash */
   kvtree* meta_hash = kvtree_new();
-  kvtree_setf(meta_hash, current_hash, "%d", rank_world);
+  kvtree_setf(meta_hash, current_hash, "%d", rank);
 
   /* sort the header to list items alphabetically,
    * this isn't strictly required, but it ensures the kvtrees
@@ -117,87 +119,34 @@ int redset_recover_single(
   const char* name,
   const redset_base* d)
 {
-  int i;
   int rc = REDSET_SUCCESS;
 
   MPI_Comm comm_world = d->parent_comm;
 
-  /* get name of this process (use rank in COMM_WORLD for now) */
-  int rank_world;
-  MPI_Comm_rank(comm_world, &rank_world);
-
   /* assume files exist for this process */
-  int valid = 1;
+  int have_my_files = 1;
 
-  /* read meta data from file in directory */
-  kvtree* meta_hash = kvtree_new();
-  char filename[REDSET_MAX_FILENAME];
-  redset_build_single_filename(name, d, filename, sizeof(filename));
-  kvtree_read_file(filename, meta_hash);
+  /* check whether we have our files */
+  kvtree* header = kvtree_new();
+  if (redset_read_single_file(name, d, header) == REDSET_SUCCESS) {
+    /* use our global rank for single */
+    int rank;
+    MPI_Comm_rank(comm_world, &rank);
 
-  /* get pointer to hash for this rank */
-  kvtree* current_hash = kvtree_getf(meta_hash, "%d", rank_world);
-  if (current_hash == NULL) {
-    valid = 0;
-  }
-
-  /* read total number of files we have */
-  int numfiles_saved = -1;
-  if (kvtree_util_get_int(current_hash, "FILES", &numfiles_saved) == KVTREE_SUCCESS) {
-//  if (numfiles != numfiles_saved) {
-//    valid = 0;
-//  }
+    /* get pointer to hash for this rank */
+    kvtree* current_hash = kvtree_getf(header, "%d", rank);
+    if (redset_file_check(current_hash) != REDSET_SUCCESS) {
+      /* some data file is bad */
+      have_my_files = 0;
+    }
   } else {
-    /* number of files not recorded */
-    valid = 0;
+    /* failed to read redundancy file */
+    have_my_files = 0;
   }
-
-  /* verify that we have each file and that the size is correct for each one */
-  kvtree* files_hash = kvtree_get(current_hash, "FILE");
-  for (i = 0; i < numfiles_saved; i++) {
-    /* get file name of this file */
-    kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
-    kvtree_elem* elem = kvtree_elem_first(index_hash);
-    const char* file_name = kvtree_elem_key(elem);
-
-    /* lookup hash for this file */
-    kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
-    if (file_hash == NULL) {
-      /* failed to find file name recorded */
-      valid = 0;
-      continue;
-    }
-
-    /* check that file exists */
-    if (redset_file_exists(file_name) != REDSET_SUCCESS) {
-      /* failed to find file */
-      valid = 0;
-      continue;
-    }
-
-    /* get file size of this file */
-    unsigned long file_size = redset_file_size(file_name);
-
-    /* lookup expected file size and compare to actual size */
-    unsigned long file_size_saved;
-    if (kvtree_util_get_bytecount(file_hash, "SIZE", &file_size_saved) == KVTREE_SUCCESS) {
-      if (file_size != file_size_saved) {
-        /* file size does not match */
-        valid = 0;
-        continue;
-      }
-    } else {
-      /* file size not recorded */
-      valid = 0;
-      continue;
-    }
-  }
-
-  /* delete the hash */
-  kvtree_delete(&meta_hash);
+  kvtree_delete(&header);
 
   /* determine whether all ranks have their files */
-  if (! redset_alltrue(valid, comm_world)) {
+  if (! redset_alltrue(have_my_files, comm_world)) {
     rc = REDSET_FAILURE;
   }
 

--- a/src/redset_util.c
+++ b/src/redset_util.c
@@ -283,3 +283,289 @@ void redset_buffers_free(int num, void* pbufs)
 
   return;
 }
+
+int redset_file_encode_kvtree(kvtree* hash, int num, const char** files)
+{
+  int rc = REDSET_SUCCESS;
+
+  /* record total number of files we have */
+  kvtree_set_kv_int(hash, "FILES", num);
+
+  /* enter index, name, and size of each file */
+  int i;
+  kvtree* files_hash = kvtree_set(hash, "FILE", kvtree_new());
+  for (i = 0; i < num; i++) {
+    /* get file name of this file */
+    const char* file = files[i];
+
+    /* add entry for this file, including its index, name, and size */
+    kvtree* file_hash = kvtree_setf(files_hash, kvtree_new(), "%d %s", i, file);
+
+    /* record file meta data of this file */
+    redset_meta_encode(file, file_hash);
+  }
+
+  return rc;
+}
+
+int redset_file_check(kvtree* hash)
+{
+  int rc = REDSET_SUCCESS;
+
+  /* check that we got a hash to work with */
+  if (hash == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  /* lookup number of files this process wrote */
+  int num;
+  if (kvtree_util_get_int(hash, "FILES", &num) != REDSET_SUCCESS) {
+    /* number of files missing from hash */
+    return REDSET_FAILURE;
+  }
+
+  /* assume we have our files */
+  int have_my_files = 1;
+
+  /* check that each of our data files exists and is the correct size */
+  int i;
+  kvtree* files_hash = kvtree_get(hash, "FILE");
+  for (i = 0; i < num; i++) {
+    /* get file name of this file */
+    kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
+    kvtree_elem* elem = kvtree_elem_first(index_hash);
+    const char* file = kvtree_elem_key(elem);
+  
+    /* lookup hash for this file */
+    kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file);
+    if (file_hash == NULL) {
+      /* failed to find file name recorded */
+      have_my_files = 0;
+      continue;
+    }
+  
+    /* check that file exists */
+    if (redset_file_exists(file) != REDSET_SUCCESS) {
+      /* failed to find file */
+      have_my_files = 0;
+      continue;
+    }
+  
+    /* get file size of this file */
+    unsigned long file_size = redset_file_size(file);
+  
+    /* lookup expected file size and compare to actual size */
+    unsigned long file_size_saved;
+    if (kvtree_util_get_bytecount(file_hash, "SIZE", &file_size_saved) == KVTREE_SUCCESS) {
+      if (file_size != file_size_saved) {
+        /* file size does not match */
+        have_my_files = 0;
+        continue;
+      }
+    } else {
+      /* file size not recorded */
+      have_my_files = 0;
+      continue;
+    }
+  }
+
+  /* return failure if some file failed to check out */
+  if (! have_my_files) {
+    rc = REDSET_FAILURE;
+  }
+
+  return rc;
+}
+
+/* given a hash that defines a set of files, open our logical file for reading */
+int redset_file_open(const kvtree* hash, int flags, mode_t mode, redset_file* rsf)
+{
+  int rc = REDSET_SUCCESS;
+
+  /* bail out if we're not given a logical file structure to write to */
+  if (rsf == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  /* initialize fields in caller's structure */
+  rsf->numfiles  = 0;
+  rsf->bytes     = 0;
+  rsf->fds       = NULL;
+  rsf->filenames = NULL;
+  rsf->filesizes = NULL;
+
+  /* lookup number of files this process wrote */
+  int num_files = 0;
+  if (kvtree_util_get_int(hash, "FILES", &num_files) != REDSET_SUCCESS) {
+    redset_err("Failed to read number of files from hash @ %s:%d",
+      __FILE__, __LINE__
+    );
+    return REDSET_FAILURE;
+  }
+
+  /* allocate arrays to hold file descriptors, filenames, and filesizes for each of our files */
+  int* fds                 = (int*)           REDSET_MALLOC(num_files * sizeof(int));
+  const char** filenames   = (const char**)   REDSET_MALLOC(num_files * sizeof(char*));
+  unsigned long* filesizes = (unsigned long*) REDSET_MALLOC(num_files * sizeof(unsigned long));
+
+  unsigned long bytes = 0;
+
+  /* open each of our files */
+  int i;
+  kvtree* files_hash = kvtree_get(hash, "FILE");
+  for (i = 0; i < num_files; i++) {
+    /* get file name of this file */
+    kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
+    kvtree_elem* elem = kvtree_elem_first(index_hash);
+    const char* file_name = kvtree_elem_key(elem);
+  
+    /* lookup hash for this file */
+    kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
+
+    /* copy the full filename */
+    filenames[i] = strdup(file_name);
+    if (filenames[i] == NULL) {
+      redset_abort(-1, "Failed to copy filename %s @ %s:%d",
+        file_name, __FILE__, __LINE__
+      );
+    }
+
+    /* lookup the filesize */
+    if (kvtree_util_get_bytecount(file_hash, "SIZE", &filesizes[i]) != REDSET_SUCCESS) {
+      redset_abort(-1, "Failed to read file size for file %s @ %s:%d",
+        file_name, __FILE__, __LINE__
+      );
+    }
+
+    /* sum up bytes in our of our files */
+    bytes += filesizes[i];
+
+    /* open the file for reading */
+    if ((mode & O_RDONLY) == O_RDONLY) {
+      fds[i] = redset_open(file_name, flags);
+      if (fds[i] < 0) {
+        redset_abort(-1, "Opening file for reading: redset_open(%s, O_RDONLY) errno=%d %s @ %s:%d",
+          file_name, errno, strerror(errno), __FILE__, __LINE__
+        );
+      }
+    } else {
+      fds[i] = redset_open(file_name, flags, mode);
+      if (fds[i] < 0) {
+        redset_abort(-1, "Opening file for writing: redset_open(%s, O_RDONLY) errno=%d %s @ %s:%d",
+          file_name, errno, strerror(errno), __FILE__, __LINE__
+        );
+      }
+    }
+  }
+
+  /* success if we made it here, copy everything to output struct */
+  rsf->numfiles  = num_files;
+  rsf->bytes     = bytes;
+  rsf->fds       = fds;
+  rsf->filenames = filenames;
+  rsf->filesizes = filesizes;  
+
+  return rc;
+}
+
+/* return file size of our logical file */
+unsigned long redset_file_bytes(redset_file* rsf)
+{
+  if (rsf == NULL) {
+    return 0;
+  }
+  return rsf->bytes;
+}
+
+/* read from logical file */
+int redset_file_pread(redset_file* rsf, void* buf, size_t count, off_t offset)
+{
+  if (rsf == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  int rc = redset_read_pad_n(rsf->numfiles, rsf->filenames, rsf->fds,
+    buf, count, offset, rsf->filesizes
+  );
+
+  return rc;
+}
+
+/* write to logical file */
+int redset_file_pwrite(redset_file* rsf, void* buf, size_t count, off_t offset)
+{
+  if (rsf == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  int rc = redset_write_pad_n(rsf->numfiles, rsf->filenames, rsf->fds,
+    buf, count, offset, rsf->filesizes
+  );
+
+  return rc;
+}
+
+/* given a hash that defines a set of files, close our logical */
+int redset_file_close(redset_file* rsf)
+{
+  if (rsf == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  int rc = REDSET_SUCCESS;
+
+  /* close each file */
+  int i;
+  for (i = 0; i < rsf->numfiles; i++) {
+    int fd = rsf->fds[i];
+    const char* file = rsf->filenames[i];
+    if (redset_close(file, fd) != REDSET_SUCCESS) {
+      redset_err("Error closing file: redset_close(%s) errno=%d %s @ %s:%d",
+        file, errno, strerror(errno), __FILE__, __LINE__
+      );
+      rc = REDSET_FAILURE;
+    }
+
+    /* free file name strdup'd during open */
+    redset_free(&rsf->filenames[i]);
+  }
+
+  return rc;
+}
+
+/* given a hash that defines a set of files, apply metadata recorded to each file */
+int redset_file_apply_meta(kvtree* hash)
+{
+  if (hash == NULL) {
+    return REDSET_FAILURE;
+  }
+
+  int rc = REDSET_SUCCESS;
+
+  /* lookup number of files this process wrote */
+  int num_files = 0;
+  if (kvtree_util_get_int(hash, "FILES", &num_files) != REDSET_SUCCESS) {
+    redset_err("Failed to read number of files from hash @ %s:%d",
+      __FILE__, __LINE__
+    );
+    return REDSET_FAILURE;
+  }
+
+  /* we've written data for all files */
+  int i;
+  kvtree* files_hash = kvtree_get(hash, "FILE");
+  for (i = 0; i < num_files; i++) {
+    /* get file name of this file */
+    kvtree* index_hash = kvtree_getf(files_hash, "%d", i);
+    kvtree_elem* elem = kvtree_elem_first(index_hash);
+    const char* file_name = kvtree_elem_key(elem);
+  
+    /* lookup hash for this file */
+    kvtree* file_hash = kvtree_getf(files_hash, "%d %s", i, file_name);
+
+    /* set metadata properties on rebuilt file */
+    redset_meta_apply(file_name, file_hash);
+  }
+
+  return rc;
+}

--- a/src/redset_util.h
+++ b/src/redset_util.h
@@ -1,6 +1,10 @@
 #ifndef REDSET_UTIL_H
 #define REDSET_UTIL_H
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
 #include "mpi.h"
 #include "kvtree.h"
 
@@ -64,5 +68,39 @@ void** redset_buffers_alloc(int num, size_t size);
 
 /* free a set of buffers allocated in redset_buffers_alloc */
 void redset_buffers_free(int num, void* pbufs);
+
+/* structure to track an ordered set of files and operate on
+ * them as one logical, continuous file */
+typedef struct {
+  int numfiles;             /* number of files in list */
+  off_t bytes;              /* number of bytes summed across all files */
+  int* fds;                 /* file descriptor for each file */
+  const char** filenames;   /* name of each file */
+  unsigned long* filesizes; /* size of each file */
+} redset_file;
+
+/* encode file info into kvtree */
+int redset_file_encode_kvtree(kvtree* hash, int num, const char** files);
+
+/* check whether files in kvtree exist and match expected properties */
+int redset_file_check(kvtree* hash);
+
+/* given a hash that defines a set of files, open our logical file for reading */
+int redset_file_open(const kvtree* hash, int flags, mode_t mode, redset_file* rsf);
+
+/* return file size of our logical file */
+unsigned long redset_file_bytes(redset_file* rsf);
+
+/* read from logical file */
+int redset_file_pread(redset_file* rsf, void* buf, size_t count, off_t offset);
+
+/* write to logical file */
+int redset_file_pwrite(redset_file* rsf, void* buf, size_t count, off_t offset);
+
+/* given a hash that defines a set of files, close our logical */
+int redset_file_close(redset_file* rsf);
+
+/* given a hash that defines a set of files, apply metadata recorded to each file */
+int redset_file_apply_meta(kvtree* hash);
 
 #endif

--- a/src/redset_util.h
+++ b/src/redset_util.h
@@ -59,4 +59,10 @@ int redset_alltrue(int flag, MPI_Comm comm);
 /* recursively sort a kvtree in alphabetical order */
 void redset_sort_kvtree(kvtree* hash);
 
+/* allocate a set of buffers for MPI communication or redundancy encoding */
+void** redset_buffers_alloc(int num, size_t size);
+
+/* free a set of buffers allocated in redset_buffers_alloc */
+void redset_buffers_free(int num, void* pbufs);
+
 #endif

--- a/src/redset_xor.c
+++ b/src/redset_xor.c
@@ -69,7 +69,7 @@ static int redset_read_xor_file(
 
 /* given a redundancy descriptor with all top level fields filled in
  * allocate and fill in structure for xor specific fields in state */
-int redset_create_xor(MPI_Comm parent_comm, redset_base* d)
+int redset_construct_xor(MPI_Comm parent_comm, redset_base* d)
 {
   int rc = REDSET_SUCCESS;
 

--- a/src/redset_xor.c
+++ b/src/redset_xor.c
@@ -321,6 +321,12 @@ int redset_apply_xor(
     );
   }
 
+  /* sort the header to list items alphabetically,
+   * this isn't strictly required, but it ensures the kvtrees
+   * are stored in the same byte order so that we can reproduce
+   * the redundancy file identically on a rebuild */
+  redset_sort_kvtree(header);
+
   /* write out the xor chunk header */
   kvtree_write_fd(my_chunk_file, fd_xor, header);
   kvtree_delete(&header);
@@ -583,6 +589,12 @@ int redset_recover_xor_rebuild(
         xor_file, errno, strerror(errno), __FILE__, __LINE__
       );
     }
+
+    /* sort the header to list items alphabetically,
+     * this isn't strictly required, but it ensures the kvtrees
+     * are stored in the same byte order so that we can reproduce
+     * the redundancy file identically on a rebuild */
+    redset_sort_kvtree(header);
 
     /* write XOR chunk file header */
     kvtree_write_fd(xor_file, fd_xor, header);

--- a/test/test_redset.c
+++ b/test/test_redset.c
@@ -427,7 +427,7 @@ int test_recover_loss_two_ranks(int mode, const char* path, int count, const cha
       printf("mode = %d: Recover time (two ranks): %f\n", mode, (end - start));
     }
 
-    if (mode != REDSET_COPY_RS) {
+    if (mode == REDSET_COPY_SINGLE || mode == REDSET_COPY_XOR) {
       if (recovered) {
         printf("ERROR: should not have be able to recover files\n");
         rc = 1;
@@ -470,7 +470,7 @@ int test_recover_loss_two_ranks(int mode, const char* path, int count, const cha
     redset_rc = redset_recover(comm, path, &d);
     recovered = alltrue(redset_rc == REDSET_SUCCESS, comm);
   
-    if (mode != REDSET_COPY_RS) {
+    if (mode == REDSET_COPY_SINGLE || mode == REDSET_COPY_XOR) {
       if (recovered) {
         printf("ERROR: should not have be able to recover files\n");
         rc = 1;
@@ -505,6 +505,176 @@ int test_recover_loss_two_ranks(int mode, const char* path, int count, const cha
   return rc;
 }
 
+int increment_index(int* index, int i, int k, int ranks)
+{
+  /* compute limit of current index */
+  int limit = ranks - (k - i);
+  if (index[i] < limit) {
+    /* current index is below its limit, bump it up */
+    index[i]++;
+    return 0;
+  } else if (i > 0) {
+    /* current index has reached its limit,
+     * try to bump the next index down if there is one */
+    increment_index(index, i - 1, k, ranks);
+
+    /* reset current index to one more than index below */
+    index[i] = index[i - 1] + 1;
+  } else {
+    /* we've exhausted the lowest index value,
+     * bump it up anyway so higher index values
+     * also exceed their limits */
+    index[i]++;
+  }
+
+  if (index[i] > limit) {
+    /* we've exhausted the range for this value */
+    return 1;
+  }
+
+  /* otherwise, we found a valid index value */
+  return 0;
+}
+
+/* test that recover succeeds when no files are lost,
+ * nothing to do, but should still return success */
+int test_recover_loss_k_ranks(int mode, const char* path, int count, const char** filelist, uLong* crcvals, int k, MPI_Comm comm)
+{
+  int rc = 0;
+
+  int rank, ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+  int* index = (int*) malloc(k * sizeof(int));
+
+  /* initialize index values to 0, 1, ..., k-1 */
+  int i;
+  for (i = 0; i < k; i++) {
+    index[i] = i;
+  }
+
+  int done = 0;
+  while (! done) {
+    /* delete files on rank 0 */
+    if (rank == 0) {
+      printf("mode = %d: deleting ranks = ", mode); 
+      for (i = 0; i < k; i++) {
+        printf("%d, ", index[i]); 
+      }
+      printf("\n");
+      fflush(stdout);
+    }
+    for (i = 0; i < k; i++) {
+      if (rank == index[i]) {
+        delete_files(count, filelist);
+      }
+    }
+  
+    double start = MPI_Wtime();
+
+    redset d;
+    int redset_rc = redset_recover(comm, path, &d);
+    int recovered = alltrue(redset_rc == REDSET_SUCCESS, comm);
+  
+    double end = MPI_Wtime();
+    if (rank == 0) {
+      printf("mode = %d: Recover time (two ranks): %f\n", mode, (end - start));
+    }
+
+    if ((mode == REDSET_COPY_SINGLE && k > 0) ||
+        (mode == REDSET_COPY_XOR    && k > 1))
+     {
+      if (recovered) {
+        printf("ERROR: should not have be able to recover files\n");
+        rc = 1;
+      }
+    } else {
+      if (recovered) {
+        rc = check_crcs(count, filelist, crcvals);
+      } else {
+        printf("ERROR: recover failed\n");
+        rc = 1;
+      }
+  
+      int tmp_rc = check_for_redundancy_files(mode, path, d);
+      if (tmp_rc) {
+        rc = tmp_rc;
+      }
+    }
+  
+    if (rc == 0 && recovered) {
+      /* delete files on rank 0 */
+      if (rank == 0) {
+        printf("mode = %d: deleting ranks and redundancy = ", mode); 
+        for (i = 0; i < k; i++) {
+          printf("%d, ", index[i]); 
+        }
+        printf("\n");
+        fflush(stdout);
+      }
+      for (i = 0; i < k; i++) {
+        if (rank == index[i]) {
+          delete_files(count, filelist);
+          delete_redundancy_files(mode, path, d);
+        }
+      }
+    }
+
+    if (redset_delete(&d) != REDSET_SUCCESS) {
+      printf("ERROR: failed to delete redundancy descriptor\n");
+      rc = 1;
+    }
+
+    /* current rank failed to recover, so no need to test other ranks */
+    if (rc || !recovered) {
+      fflush(stdout);
+      return 1;
+    }
+
+    redset_rc = redset_recover(comm, path, &d);
+    recovered = alltrue(redset_rc == REDSET_SUCCESS, comm);
+  
+    if ((mode == REDSET_COPY_SINGLE && k > 0) ||
+        (mode == REDSET_COPY_XOR    && k > 1))
+    {
+      if (recovered) {
+        printf("ERROR: should not have be able to recover files\n");
+        rc = 1;
+      }
+    } else {
+      if (recovered) {
+        rc = check_crcs(count, filelist, crcvals);
+      } else {
+        printf("ERROR: recover failed\n");
+        rc = 1;
+      }
+  
+      int tmp_rc = check_for_redundancy_files(mode, path, d);
+      if (tmp_rc) {
+        rc = tmp_rc;
+      }
+    }
+  
+    if (redset_delete(&d) != REDSET_SUCCESS) {
+      printf("ERROR: failed to delete redundancy descriptor\n");
+      rc = 1;
+    }
+
+    /* current rank failed to recover, so no need to test other ranks */
+    if (rc || !recovered) {
+      fflush(stdout);
+      return 1;
+    }
+
+    done = increment_index(index, k-1, k, ranks);
+  }
+
+  free(index);
+
+  return rc;
+}
+
 void test_sequence(int copymode, const char* group, int filecount, const char** filelist, const char* prefix)
 {
   create_files(filecount, filelist);
@@ -513,7 +683,21 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
   init_crcs(filecount, filelist, crcvals);
 
   redset d;
-  redset_create(copymode, MPI_COMM_WORLD, group, &d);
+  //redset_create(copymode, MPI_COMM_WORLD, group, &d);
+  switch (copymode) {
+  case REDSET_COPY_SINGLE:
+    redset_new_single(MPI_COMM_WORLD, group, &d);
+    break;
+  case REDSET_COPY_PARTNER:
+    redset_new_partner(MPI_COMM_WORLD, group, 2, &d);
+    break;
+  case REDSET_COPY_XOR:
+    redset_new_xor(MPI_COMM_WORLD, group, 8, &d);
+    break;
+  case REDSET_COPY_RS:
+    redset_new_rs(MPI_COMM_WORLD, group, 8, 2, &d);
+    break;
+  }
 
   test_apply(copymode, filecount, filelist, prefix, d, MPI_COMM_WORLD);
   check_crcs(filecount, filelist, crcvals);
@@ -531,21 +715,42 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
 
 
 
-  create_files(filecount, filelist);
-  init_crcs(filecount, filelist, crcvals);
+  int ranks;
+  MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
-  redset_create(copymode, MPI_COMM_WORLD, group, &d);
+  int k;
+  for (k = 2; k < ranks; k++) {
+    create_files(filecount, filelist);
+    init_crcs(filecount, filelist, crcvals);
 
-  test_apply(copymode, filecount, filelist, prefix, d, MPI_COMM_WORLD);
-  check_crcs(filecount, filelist, crcvals);
+    //redset_create(copymode, MPI_COMM_WORLD, group, &d);
+    switch (copymode) {
+    case REDSET_COPY_SINGLE:
+      redset_new_single(MPI_COMM_WORLD, group, &d);
+      break;
+    case REDSET_COPY_PARTNER:
+      redset_new_partner(MPI_COMM_WORLD, group, k, &d);
+      break;
+    case REDSET_COPY_XOR:
+      redset_new_xor(MPI_COMM_WORLD, group, 8, &d);
+      break;
+    case REDSET_COPY_RS:
+      redset_new_rs(MPI_COMM_WORLD, group, 8, k, &d);
+      break;
+    }
 
-  test_recover_loss_two_ranks(copymode, prefix, filecount, filelist, crcvals, MPI_COMM_WORLD);
+    test_apply(copymode, filecount, filelist, prefix, d, MPI_COMM_WORLD);
+    check_crcs(filecount, filelist, crcvals);
 
-  test_unapply(copymode, prefix, d, MPI_COMM_WORLD);
+    //test_recover_loss_two_ranks(copymode, prefix, filecount, filelist, crcvals, MPI_COMM_WORLD);
+    test_recover_loss_k_ranks(copymode, prefix, filecount, filelist, crcvals, k, MPI_COMM_WORLD);
 
-  redset_delete(&d);
+    test_unapply(copymode, prefix, d, MPI_COMM_WORLD);
 
-  delete_files(filecount, filelist);
+    redset_delete(&d);
+
+    delete_files(filecount, filelist);
+  }
 
   free(crcvals);
 

--- a/test/test_redset.c
+++ b/test/test_redset.c
@@ -686,16 +686,16 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
   //redset_create(copymode, MPI_COMM_WORLD, group, &d);
   switch (copymode) {
   case REDSET_COPY_SINGLE:
-    redset_new_single(MPI_COMM_WORLD, group, &d);
+    redset_create_single(MPI_COMM_WORLD, group, &d);
     break;
   case REDSET_COPY_PARTNER:
-    redset_new_partner(MPI_COMM_WORLD, group, 2, &d);
+    redset_create_partner(MPI_COMM_WORLD, group, 2, &d);
     break;
   case REDSET_COPY_XOR:
-    redset_new_xor(MPI_COMM_WORLD, group, 8, &d);
+    redset_create_xor(MPI_COMM_WORLD, group, 8, &d);
     break;
   case REDSET_COPY_RS:
-    redset_new_rs(MPI_COMM_WORLD, group, 8, 2, &d);
+    redset_create_rs(MPI_COMM_WORLD, group, 8, 2, &d);
     break;
   }
 
@@ -726,16 +726,16 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
     //redset_create(copymode, MPI_COMM_WORLD, group, &d);
     switch (copymode) {
     case REDSET_COPY_SINGLE:
-      redset_new_single(MPI_COMM_WORLD, group, &d);
+      redset_create_single(MPI_COMM_WORLD, group, &d);
       break;
     case REDSET_COPY_PARTNER:
-      redset_new_partner(MPI_COMM_WORLD, group, k, &d);
+      redset_create_partner(MPI_COMM_WORLD, group, k, &d);
       break;
     case REDSET_COPY_XOR:
-      redset_new_xor(MPI_COMM_WORLD, group, 8, &d);
+      redset_create_xor(MPI_COMM_WORLD, group, 8, &d);
       break;
     case REDSET_COPY_RS:
-      redset_new_rs(MPI_COMM_WORLD, group, 8, k, &d);
+      redset_create_rs(MPI_COMM_WORLD, group, 8, k, &d);
       break;
     }
 


### PR DESCRIPTION
This adds support so that one can specify the number of replicas used in partner.  Previously, partner was limited to one copy.  One can now specify any replica count up to one less than the size of the redundancy group.