### PR TITLE
allow user to specify set_size with partner

### DIFF
--- a/src/redset.c
+++ b/src/redset.c
@@ -374,9 +374,6 @@ static int redset_create_base(
     MPI_Comm_dup(MPI_COMM_SELF, &d->comm);
     break;
   case REDSET_COPY_PARTNER:
-    /* dup the communicator across failure groups */
-    redset_split_across(comm, comm_fail, &d->comm);
-    break;
   case REDSET_COPY_XOR:
   case REDSET_COPY_RS:
     /* split the communicator across groups based on set size
@@ -471,10 +468,10 @@ int redset_create_single(
 int redset_create_partner(
   MPI_Comm comm,
   const char* group_name,
+  int set_size,
   int replicas,
   redset* dvp)
 {
-  int set_size = 8;
   int rc = redset_create_base(REDSET_COPY_PARTNER, comm, group_name, set_size, replicas, dvp);
   return rc;
 }

--- a/src/redset.h
+++ b/src/redset.h
@@ -64,6 +64,7 @@ int redset_create_single(
 int redset_create_partner(
   MPI_Comm comm,     /**< [IN]  - process group participating in set */
   const char* group, /**< [IN]  - string specifying procs in the same failure group */
+  int size,          /**< [IN]  - minimum number of ranks for a redundancy set */
   int replicas,      /**< [IN]  - number of partner replicas */
   redset* d          /**< [OUT] - output redundancy descriptor */
 );

--- a/test/test_redset.c
+++ b/test/test_redset.c
@@ -689,7 +689,7 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
     redset_create_single(MPI_COMM_WORLD, group, &d);
     break;
   case REDSET_COPY_PARTNER:
-    redset_create_partner(MPI_COMM_WORLD, group, 2, &d);
+    redset_create_partner(MPI_COMM_WORLD, group, 8, 2, &d);
     break;
   case REDSET_COPY_XOR:
     redset_create_xor(MPI_COMM_WORLD, group, 8, &d);
@@ -729,7 +729,7 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
       redset_create_single(MPI_COMM_WORLD, group, &d);
       break;
     case REDSET_COPY_PARTNER:
-      redset_create_partner(MPI_COMM_WORLD, group, k, &d);
+      redset_create_partner(MPI_COMM_WORLD, group, 8, k, &d);
       break;
     case REDSET_COPY_XOR:
       redset_create_xor(MPI_COMM_WORLD, group, 8, &d);


### PR DESCRIPTION
Allow the user to specify the set_size with PARTNER.  Smaller sets help reduce cost of the serial rebuild for PARTNER.