### PR TITLE
apply meta to all files after rebuild to set atime on existing files

### DIFF
--- a/src/redset_partner.c
+++ b/src/redset_partner.c
@@ -961,10 +961,9 @@ int redset_recover_partner_rebuild(
     rc = REDSET_FAILURE;
   }
 
-  /* reapply metadata properties to file: uid, gid, mode bits, timestamps */
-  if (need_files) {
-    redset_lofi_apply_meta(current_hash);
-  }
+  /* reapply metadata properties to file: uid, gid, mode bits, timestamps,
+   * we do this on every file instead of just the rebuilt files so that we preserve atime on all files */
+  redset_lofi_apply_meta(current_hash);
 
   /* free the buffers */
   redset_free(&rhs_need);

--- a/src/redset_partner_serial.c
+++ b/src/redset_partner_serial.c
@@ -597,13 +597,12 @@ int redset_rebuild_partner(
     redset_close(filenames[i], fds[i]);
   }
 
-  /* copy meta data properties to new file (uid, gid, mode, atime, mtime) */
+  /* copy meta data properties to new file (uid, gid, mode, atime, mtime),
+   * and reset atime on existing files */
   if (rc == REDSET_SUCCESS) {
     for (i = 0; i < total_ranks; i++) {
-      if (missing[i]) {
-        int apply_rc = redset_lofi_apply_meta_mapped(hashes[i], map);
-        if (apply_rc != REDSET_SUCCESS) {
-        }
+      int apply_rc = redset_lofi_apply_meta_mapped(hashes[i], map);
+      if (apply_rc != REDSET_SUCCESS) {
       }
     }
   }

--- a/src/redset_reedsolomon.c
+++ b/src/redset_reedsolomon.c
@@ -1789,10 +1789,9 @@ int redset_recover_rs_rebuild(
   }
 #endif
 
-  /* reapply metadata properties to file: uid, gid, mode bits, timestamps */
-  if (need_rebuild) {
-    redset_lofi_apply_meta(current_hash);
-  }
+  /* reapply metadata properties to file: uid, gid, mode bits, timestamps,
+   * we do this on every file instead of just the rebuilt files so that we preserve atime on all files */
+  redset_lofi_apply_meta(current_hash);
 
   /* free buffers */
   redset_buffers_free(missing,  &data_bufs);

--- a/src/redset_xor.c
+++ b/src/redset_xor.c
@@ -611,10 +611,9 @@ int redset_recover_xor_rebuild(
   }
 #endif
 
-  /* reapply metadata properties to file: uid, gid, mode bits, timestamps */
-  if (root == d->rank) {
-    redset_lofi_apply_meta(current_hash);
-  }
+  /* reapply metadata properties to file: uid, gid, mode bits, timestamps,
+   * we do this on every file instead of just the rebuilt files so that we preserve atime on all files */
+  redset_lofi_apply_meta(current_hash);
 
   /* free the buffers */
   redset_buffers_free(1, &recv_bufs);

--- a/src/redset_xor_serial.c
+++ b/src/redset_xor_serial.c
@@ -575,13 +575,12 @@ int redset_rebuild_xor(
     redset_close(filenames[i], fds[i]);
   }
 
-  /* copy meta data properties to new file (uid, gid, mode, atime, mtime) */
+  /* copy meta data properties to new file (uid, gid, mode, atime, mtime),
+   * and reset atime on existing files */
   if (rc == REDSET_SUCCESS) {
     for (i = 0; i < total_ranks; i++) {
-      if (missing[i]) {
-        int apply_rc = redset_lofi_apply_meta_mapped(hashes[i], map);
-        if (apply_rc != REDSET_SUCCESS) {
-        }
+      int apply_rc = redset_lofi_apply_meta_mapped(hashes[i], map);
+      if (apply_rc != REDSET_SUCCESS) {
       }
     }
   }


### PR DESCRIPTION
Set metadata on all files after a rebuild, so that we also reset atime on existing files that we had to read from in order to rebuild the lost files.