### PR TITLE
add key value configuration interface to to redset

### DIFF
--- a/src/redset.c
+++ b/src/redset.c
@@ -25,7 +25,7 @@
 
 #define REDSET_HOSTNAME (255)
 
-int redset_init()
+int redset_init(void)
 {
   /* read our hostname */
   char hostname[REDSET_HOSTNAME + 1];
@@ -44,7 +44,7 @@ int redset_init()
   return REDSET_SUCCESS;
 }
 
-int redset_finalize()
+int redset_finalize(void)
 {
   redset_free(&redset_hostname);
   return REDSET_SUCCESS;

--- a/src/redset.h
+++ b/src/redset.h
@@ -40,10 +40,10 @@ typedef void* redset_filelist;
 ///@{
 
 /** initialize library */
-int redset_init();
+int redset_init(void);
 
 /** shutdown library */
-int redset_finalize();
+int redset_finalize(void);
 
 /** create a new redundancy set descriptor */
 int redset_create(

--- a/src/redset.h
+++ b/src/redset.h
@@ -2,7 +2,6 @@
 #define REDSET_H
 
 #include "mpi.h"
-#include "kvtree.h"
 
 /** \defgroup redset Redset
  *  \brief Redundancy encoding file sets
@@ -28,6 +27,11 @@ extern "C" {
 #define REDSET_COPY_XOR     (3)
 #define REDSET_COPY_RS      (4)
 
+/* names of user settable config parameters */
+#define REDSET_KEY_CONFIG_SET_SIZE  "SETSIZE"
+#define REDSET_KEY_CONFIG_MPI_BUF_SIZE "MPI_BUF_SIZE"
+#define REDSET_KEY_CONFIG_DEBUG "DEBUG"
+
 /********************************************************/
 /** \name Define redundancy descriptor structure */
 ///@{
@@ -44,6 +48,34 @@ int redset_init(void);
 
 /** shutdown library */
 int redset_finalize(void);
+
+/* needs to be above doxygen comment to get association right */
+typedef struct kvtree_struct kvtree;
+
+/**
+ * Get/set redset configuration values.
+ *
+ * The following configuration options can be set (type in parenthesis):
+ *   * "DEBUG" (int) - if non-zero, output debug information from inside
+ *     redset.
+ *   * "SETSIZE" (int) - set size for redset to use.
+ *   * "MPI_BUF_SIZE" (byte count [IN], int [OUT]) - MPI buffer size to chunk
+ *     file transfer. Must not exceed INT_MAX.
+ *   .
+ * Symbolic names REDSET_KEY_CONFIG_FOO are defined in redset.h and should
+ * be used instead of the strings whenever possible to guard against typos in
+ * strings.
+ *
+ * \result If config != NULL, then return config on success.  If config == NULL
+ *         (you're querying the config) then return a new kvtree on success,
+ *         which must be kvtree_delete()ed by the caller. NULL on any failures.
+ * \param config The new configuration. If config == NULL, then return a new
+ *               kvtree with all the configuration values.
+ *
+ */
+kvtree* redset_config(
+  const kvtree *config /** < [IN] - options to be set */
+);
 
 /** create a new redundancy set descriptor */
 int redset_create(

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -10,6 +10,24 @@
 
 #define REDSET_VERSION "1.0"
 
+/* names of parameters used when serializing a redset to disk */
+#define REDSET_KEY_CONFIG_ENABLED   "ENABLED"
+#define REDSET_KEY_CONFIG_INTERVAL  "INTERVAL"
+#define REDSET_KEY_CONFIG_OUTPUT    "OUTPUT"
+#define REDSET_KEY_CONFIG_STORE     "STORE"
+#define REDSET_KEY_CONFIG_DIRECTORY "DIR"
+#define REDSET_KEY_CONFIG_TYPE      "TYPE"
+#define REDSET_KEY_CONFIG_GROUP      "GROUP"
+#define REDSET_KEY_CONFIG_GROUPS     "GROUPS"
+#define REDSET_KEY_CONFIG_GROUP_ID   "GROUP"
+#define REDSET_KEY_CONFIG_GROUP_SIZE "RANKS"
+#define REDSET_KEY_CONFIG_GROUP_RANK "RANK"
+
+#define REDSET_KEY_COPY_XOR_RANKS "RANKS"
+#define REDSET_KEY_COPY_XOR_GROUP "GROUP"
+#define REDSET_KEY_COPY_XOR_GROUP_RANK  "RANK"
+#define REDSET_KEY_COPY_XOR_GROUP_RANKS "RANKS"
+
 typedef struct {
   int      enabled;        /* flag indicating whether this descriptor is active */
   int      type;           /* redundancy scheme to apply */
@@ -64,6 +82,9 @@ typedef struct {
   int count;
   const char** files;
 } redset_list;
+
+/** default set size for redset to use */
+extern int redset_set_size;
 
 int redset_set_partners(
   MPI_Comm parent_comm, MPI_Comm comm, int dist,

--- a/src/redset_util.h
+++ b/src/redset_util.h
@@ -12,6 +12,8 @@
 
 #define REDSET_MAX_FILENAME (1024)
 
+extern int redset_debug;
+
 extern int redset_rank;
 extern char* redset_hostname;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 ###############
 # Build tests
 ###############
+INCLUDE_DIRECTORIES(${PROJECT_BINARY_DIR})
 
 ################
 # Add tests to ctest
@@ -8,7 +9,11 @@
 
 ADD_EXECUTABLE(redset_test test_redset.c)
 TARGET_LINK_LIBRARIES(redset_test ${SPATH_EXTERNAL_LIBS} redset)
-ADD_TEST(NAME redset_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 -N2 ./redset_test)
+ADD_TEST(NAME redset_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 -N 2 ./redset_test)
+
+ADD_EXECUTABLE(test_config test_config.c)
+TARGET_LINK_LIBRARIES(test_config ${SPATH_EXTERNAL_LIBS} redset)
+ADD_TEST(NAME test_config COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ./test_config)
 
 ####################
 # make a verbose "test" target named "check"

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -1,0 +1,228 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "redset.h"
+#include "redset_util.h"
+#include "redset_internal.h"
+
+#include "kvtree.h"
+#include "kvtree_util.h"
+
+/* helper function to check for known options */
+void check_known_options(const kvtree* configured_values,
+                         const char* known_options[])
+{
+  /* report all unknown options (typos?) */
+  const kvtree_elem* elem;
+  for (elem = kvtree_elem_first(configured_values);
+       elem != NULL;
+       elem = kvtree_elem_next(elem))
+  {
+    const char* key = kvtree_elem_key(elem);
+
+    /* must be only one level deep, ie plain kev = value */
+    const kvtree* elem_hash = kvtree_elem_hash(elem);
+    if (kvtree_size(elem_hash) != 1) {
+      printf("Element %s has unexpected number of values: %d", key,
+           kvtree_size(elem_hash));
+      exit(EXIT_FAILURE);
+    }
+
+    const kvtree* kvtree_first_elem_hash =
+      kvtree_elem_hash(kvtree_elem_first(elem_hash));
+    if (kvtree_size(kvtree_first_elem_hash) != 0) {
+      printf("Element %s is not a pure value", key);
+      exit(EXIT_FAILURE);
+    }
+
+    /* check against known options */
+    const char** opt;
+    int found = 0;
+    for (opt = known_options; *opt != NULL; opt++) {
+      if (strcmp(*opt, key) == 0) {
+        found = 1;
+        break;
+      }
+    }
+    if (! found) {
+      printf("Unknown configuration parameter '%s' with value '%s'\n",
+        kvtree_elem_key(elem),
+        kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem)))
+      );
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
+/* helper function to check option values in kvtree against expected values */
+void check_options(const int exp_debug, const int exp_set_size, const int exp_mpi_buf_size)
+{
+  kvtree* config = redset_config(NULL);
+  if (config == NULL) {
+    printf("redset_config failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_debug;
+  if (kvtree_util_get_int(config, REDSET_KEY_CONFIG_DEBUG, &cfg_debug) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from redset_config\n",
+           REDSET_KEY_CONFIG_DEBUG);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_debug != exp_debug) {
+    printf("redset_config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_debug, REDSET_KEY_CONFIG_DEBUG,
+           exp_debug);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_set_size;
+  if (kvtree_util_get_int(config, REDSET_KEY_CONFIG_SET_SIZE, &cfg_set_size) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from redset_config\n",
+           REDSET_KEY_CONFIG_SET_SIZE);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_set_size != exp_set_size) {
+    printf("redset_config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_set_size, REDSET_KEY_CONFIG_SET_SIZE,
+           exp_set_size);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_mpi_buf_size;
+  if (kvtree_util_get_int(config, REDSET_KEY_CONFIG_MPI_BUF_SIZE,
+                          &cfg_mpi_buf_size) != KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from redset_config\n",
+           REDSET_KEY_CONFIG_MPI_BUF_SIZE);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_mpi_buf_size != exp_mpi_buf_size) {
+    printf("redset_config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_mpi_buf_size, REDSET_KEY_CONFIG_MPI_BUF_SIZE,
+           exp_mpi_buf_size);
+    exit(EXIT_FAILURE);
+  }
+
+  static const char* known_options[] = {
+    REDSET_KEY_CONFIG_DEBUG,
+    REDSET_KEY_CONFIG_SET_SIZE,
+    REDSET_KEY_CONFIG_MPI_BUF_SIZE,
+    NULL
+  };
+  check_known_options(config, known_options);
+
+  kvtree_delete(&config);
+}
+
+int
+main(int argc, char *argv[]) {
+    int rc;
+    kvtree* redset_config_values = kvtree_new();
+
+    MPI_Init(&argc, &argv);
+
+    rc = redset_init();
+    if (rc != REDSET_SUCCESS) {
+        printf("redset_init() failed (error %d)\n", rc);
+        return rc;
+    }
+
+    int old_redset_debug = redset_debug;
+    int old_redset_set_size = redset_set_size;
+    int old_redset_mpi_buf_size = redset_mpi_buf_size;
+
+    int new_redset_debug = !old_redset_debug;
+    int new_redset_set_size = old_redset_set_size + 1;
+    int new_redset_mpi_buf_size = old_redset_mpi_buf_size + 1;
+
+    check_options(old_redset_debug, old_redset_set_size,
+                  old_redset_mpi_buf_size);
+
+    /* check redset configuration settings */
+    rc = kvtree_util_set_int(redset_config_values, REDSET_KEY_CONFIG_DEBUG,
+                             new_redset_debug);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+    rc = kvtree_util_set_int(redset_config_values, REDSET_KEY_CONFIG_SET_SIZE,
+                             new_redset_set_size);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+
+    printf("Configuring redset (first set of options)...\n");
+    if (redset_config(redset_config_values) == NULL) {
+        printf("redset_config() failed\n");
+        return EXIT_FAILURE;
+    }
+
+    if (redset_debug != new_redset_debug) {
+        printf("redset_config() failed to set %s: %d != %d\n",
+               REDSET_KEY_CONFIG_DEBUG, redset_debug, new_redset_debug);
+        return EXIT_FAILURE;
+    }
+
+    if (redset_set_size != new_redset_set_size) {
+        printf("REDSET_Config() failed to set %s: %d != %d\n",
+               REDSET_KEY_CONFIG_SET_SIZE, redset_set_size, old_redset_set_size);
+        return EXIT_FAILURE;
+    }
+
+    check_options(new_redset_debug, new_redset_set_size,
+                  old_redset_mpi_buf_size);
+
+    /* configure remaining options */
+    kvtree_delete(&redset_config_values);
+    redset_config_values = kvtree_new();
+
+    rc = kvtree_util_set_int(redset_config_values, REDSET_KEY_CONFIG_MPI_BUF_SIZE,
+                             new_redset_mpi_buf_size);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+
+    printf("Configuring redset (second set of options)...\n");
+    if (redset_config(redset_config_values) == NULL) {
+        printf("redset_config() failed\n");
+        return EXIT_FAILURE;
+    }
+
+    if (redset_debug != new_redset_debug) {
+        printf("redset_config() failed to set %s: %d != %d\n",
+               REDSET_KEY_CONFIG_DEBUG, redset_debug, new_redset_debug);
+        return EXIT_FAILURE;
+    }
+
+    if (redset_set_size != new_redset_set_size) {
+        printf("REDSET_Config() failed to set %s: %d != %d\n",
+               REDSET_KEY_CONFIG_SET_SIZE, redset_set_size, old_redset_set_size);
+        return EXIT_FAILURE;
+    }
+
+    if (redset_mpi_buf_size != new_redset_mpi_buf_size) {
+        printf("REDSET_Config() failed to set %s: %d != %d\n",
+               REDSET_KEY_CONFIG_MPI_BUF_SIZE, redset_mpi_buf_size,
+               old_redset_mpi_buf_size);
+        return EXIT_FAILURE;
+    }
+
+    check_options(new_redset_debug, new_redset_set_size,
+                  new_redset_mpi_buf_size);
+
+    rc = redset_finalize();
+    if (rc != REDSET_SUCCESS) {
+        printf("redset_finalize() failed (error %d)\n", rc);
+        return rc;
+    }
+
+    MPI_Finalize();
+
+    return REDSET_SUCCESS;
+}

--- a/test/test_redset.c
+++ b/test/test_redset.c
@@ -689,7 +689,7 @@ void test_sequence(int copymode, const char* group, int filecount, const char** 
     redset_create_single(MPI_COMM_WORLD, group, &d);
     break;
   case REDSET_COPY_PARTNER:
-    redset_create_partner(MPI_COMM_WORLD, group, 8, 2, &d);
+    redset_create_partner(MPI_COMM_WORLD, group, 8, 1, &d);
     break;
   case REDSET_COPY_XOR:
     redset_create_xor(MPI_COMM_WORLD, group, 8, &d);


### PR DESCRIPTION
This pull request adds a configuration interface to filo, similar in functionality to the one in AXL. Specifically it adds a new function redset_config:

```
/**
 * Get/set redset configuration values.
 *
 * The following configuration options can be set (type in parenthesis):
 *   * "DEBUG" (int) - if non-zero, output debug information from inside
 *     redset.
 *   * "SETSIZE" (int) - set size for redset to use.
 *   * "MPI_BUF_SIZE" (byte count [IN], int [OUT]) - MPI buffer size to chunk
 *     file transfer. Must not exceed INT_MAX.
 *   .
 * Symbolic names REDSET_KEY_CONFIG_FOO are defined in redset.h and should
 * be used instead of the strings whenever possible to guard against typos in
 * strings.
 *
 * \result If config != NULL, then return config on success.  If config=NULL
 *         (you're querying the config) then return a new kvtree on success.
 *         NULL on any failures.
 * \param config The new configuration. If config=NULL, then return a kvtree
 *                with all the configuration values.
 *
 */
kvtree* redset_config(
  const kvtree *config /** < [IN] - options to be set */
);
```

as well as a new test test_config to check functionality of this interface.

Querying options will return redset's the current value of the options.

Options can be configured multiple times at runtime and it is the user's responsibility ensure that this does not lead to problems.
