### PR TITLE
fix: check that xor sets all have more than one rank

### DIFF
--- a/src/redset_xor.c
+++ b/src/redset_xor.c
@@ -146,6 +146,19 @@ int redset_construct_xor(MPI_Comm parent_comm, redset_base* d)
     );
   }
 
+  /* verify that all groups have a sufficient number of procs */
+  int valid = 1;
+  if (d->ranks <= 1) {
+    valid = 0;
+  }
+  if (! redset_alltrue(valid, parent_comm)) {
+    if (! valid) {
+      redset_abort(-1, "XOR requires at least 2 ranks per set, but found %d rank(s) in set @ %s:%d",
+        d->ranks, __FILE__, __LINE__
+      );
+    }
+  }
+
   return rc;
 }
 


### PR DESCRIPTION
The encoding schemes require redundancy groups to meet certain requirements.  For XOR, each group must have at least two members.  Partner and RS included checks, but XOR was missing its check.  This would allow an invalid group to pass through, which eventually leads to a divide by zero.  This PR adds a check to print an error message and abort, which is not great.  Though, it's better than a random divide by zero and it's consistent with how Partner and RS behave.