### PR TITLE
Incremental release v0.0.5

### DIFF
--- a/src/redset.h
+++ b/src/redset.h
@@ -21,6 +21,8 @@ extern "C" {
 
 #define REDSET_SUCCESS (0)
 
+#define REDSET_VERSION "0.0.5"
+
 #define REDSET_COPY_NULL    (0)
 #define REDSET_COPY_SINGLE  (1)
 #define REDSET_COPY_PARTNER (2)

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -8,8 +8,6 @@
 #include "redset_util.h"
 #include "redset_lofi.h"
 
-#define REDSET_VERSION "1.0"
-
 /* names of parameters used when serializing a redset to disk */
 #define REDSET_KEY_CONFIG_ENABLED   "ENABLED"
 #define REDSET_KEY_CONFIG_INTERVAL  "INTERVAL"

--- a/src/redset_util.c
+++ b/src/redset_util.c
@@ -38,8 +38,6 @@
 #include "redset_internal.h"
 #include "redset_util.h"
 
-#define REDSET_VERSION "1.0"
-
 size_t redset_page_size;
 
 /* allocate size bytes, returns NULL if size == 0,

--- a/src/redset_util_mpi.c
+++ b/src/redset_util_mpi.c
@@ -24,8 +24,6 @@
 #include "redset.h"
 #include "redset_util.h"
 
-#define REDSET_VERSION "1.0"
-
 /* sends a NUL-terminated string to a process,
  * allocates space and recieves a NUL-terminated string from a process,
  * can specify MPI_PROC_NULL as either send or recv rank */


### PR DESCRIPTION
Move `REDSET_VERSION` to _redset.h_ and update to v0.0.5 for takking
a new release.

This is in preparation for SCR 3.0rc1 and 3.0 releases and addresses the second item of #23