### PR TITLE
Add mpirun option to test_param

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ slurm-job:
     - quartz
     - batch
   variables:
-     LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 2 -p pbatch"
+    LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 2 -p pbatch"
   script:
     - ./buildme_deps
     - source /etc/profile.d/z00_lmod.sh
@@ -21,7 +21,7 @@ lsf-job:
     - lassen
     - batch
   variables:
-     LLNL_LSF_SCHEDULER_PARAMETERS: "-nnodes 2 -q pbatch"
+    LLNL_LSF_SCHEDULER_PARAMETERS: "-nnodes 2 -q pbatch"
   script:
     - ./buildme_deps
     - source /etc/profile.d/z00_lmod.sh

--- a/cmake/REDSET_ADD_TEST_PARALLEL.cmake
+++ b/cmake/REDSET_ADD_TEST_PARALLEL.cmake
@@ -1,7 +1,11 @@
 function(REDSET_ADD_TEST_PARALLEL name args outputs)
 
   # job launcher
-  if(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
+  if(NOT DEFINED VELOC_RESOURCE_MANAGER)
+    set(test_param mpirun -np 2)
+  elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "NONE")
+    set(test_param mpirun -np 2)
+  elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
     set(test_param jsrun -r 1)
   elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "SLURM")
     set(test_param srun -N 2 -n 2)

--- a/cmake/REDSET_ADD_TEST_SERIAL.cmake
+++ b/cmake/REDSET_ADD_TEST_SERIAL.cmake
@@ -1,7 +1,11 @@
 function(REDSET_ADD_TEST_SERIAL name args outputs)
 
   # job launcher
-  if(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
+  if(NOT DEFINED VELOC_RESOURCE_MANAGER)
+    set(test_param mpirun -np 2)
+  elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "NONE")
+    set(test_param mpirun -np 2)
+  elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
     set(test_param jsrun -r 1)
   elseif(${VELOC_RESOURCE_MANAGER} STREQUAL "SLURM")
     set(test_param srun -N 1 -n 1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,12 +16,10 @@ ENDIF()
 ADD_EXECUTABLE(redset_test test_redset.c)
 TARGET_LINK_LIBRARIES(redset_test ${REDSET_EXTERNAL_LIBS} ${redset_lib})
 REDSET_ADD_TEST_PARALLEL(redset_test 256 "")
-#ADD_TEST(NAME redset_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 -N 2 ./redset_test)
 
 ADD_EXECUTABLE(test_config test_config.c)
 TARGET_LINK_LIBRARIES(test_config ${REDSET_EXTERNAL_LIBS} ${redset_lib})
 REDSET_ADD_TEST_SERIAL(test_config 256 "")
-#ADD_TEST(NAME test_config COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ./test_config)
 
 ####################
 # make a verbose "test" target named "check"


### PR DESCRIPTION
Add mpirun option for running the tests when SLURM or LSF are not available.
This gets used by CI frameworks like Travis CI and GitHub Actions.