### PR TITLE
add interface to list encoded files

### DIFF
--- a/src/redset.c
+++ b/src/redset.c
@@ -1304,3 +1304,33 @@ redset_filelist redset_filelist_get(
 
   return list;
 }
+
+/* returns a list of original files encoded by redundancy descriptor */
+redset_filelist redset_filelist_orig_get(
+  const char* name,
+  const redset dvp)
+{
+  /* get pointer to redset structure */
+  redset_base* d = (redset_base*) dvp;
+
+  /* create a temporary file list to record files from redundancy scheme */
+  redset_list* tmp = NULL;
+
+  /* get files added by redundancy method */
+  switch (d->type) {
+  case REDSET_COPY_SINGLE:
+    tmp = redset_filelist_orig_get_single(name, d);
+    break;
+  case REDSET_COPY_PARTNER:
+    tmp = redset_filelist_orig_get_partner(name, d);
+    break;
+  case REDSET_COPY_XOR:
+    tmp = redset_filelist_orig_get_xor(name, d);
+    break;
+  case REDSET_COPY_RS:
+    tmp = redset_filelist_orig_get_rs(name, d);
+    break;
+  }
+
+  return tmp;
+}

--- a/src/redset.c
+++ b/src/redset.c
@@ -1240,7 +1240,7 @@ static int redset_from_dir(
 #endif
 
 /* returns a list of files added by redundancy descriptor */
-redset_filelist redset_filelist_get(
+redset_filelist redset_filelist_enc_get(
   const char* name,
   const redset dvp)
 {
@@ -1257,16 +1257,16 @@ redset_filelist redset_filelist_get(
   /* get files added by redundancy method */
   switch (d->type) {
   case REDSET_COPY_SINGLE:
-    tmp = redset_filelist_get_single(name, d);
+    tmp = redset_filelist_enc_get_single(name, d);
     break;
   case REDSET_COPY_PARTNER:
-    tmp = redset_filelist_get_partner(name, d);
+    tmp = redset_filelist_enc_get_partner(name, d);
     break;
   case REDSET_COPY_XOR:
-    tmp = redset_filelist_get_xor(name, d);
+    tmp = redset_filelist_enc_get_xor(name, d);
     break;
   case REDSET_COPY_RS:
-    tmp = redset_filelist_get_rs(name, d);
+    tmp = redset_filelist_enc_get_rs(name, d);
     break;
   }
 

--- a/src/redset.h
+++ b/src/redset.h
@@ -161,6 +161,12 @@ redset_filelist redset_filelist_get(
   const redset d    /**< [IN] - redundancy descriptor associated with above path */
 );
 
+/** return list of original files encoded by redundancy scheme */
+redset_filelist redset_filelist_orig_get(
+  const char* name, /**< [IN] - path/filename prefix to prepend to redset metadata files */
+  const redset d    /**< [IN] - redundancy descriptor associated with above path */
+);
+
 /** free file list allocated by call to redset_filelist_get */
 int redset_filelist_release(
   redset_filelist* plist /**< [INOUT] - address of pointer to list to be freed, sets pointer to NULL */

--- a/src/redset.h
+++ b/src/redset.h
@@ -156,7 +156,7 @@ int redset_unapply(
 );
 
 /** return list of files added by redundancy scheme */
-redset_filelist redset_filelist_get(
+redset_filelist redset_filelist_enc_get(
   const char* name, /**< [IN] - path/filename prefix to prepend to redset metadata files */
   const redset d    /**< [IN] - redundancy descriptor associated with above path */
 );
@@ -167,7 +167,7 @@ redset_filelist redset_filelist_orig_get(
   const redset d    /**< [IN] - redundancy descriptor associated with above path */
 );
 
-/** free file list allocated by call to redset_filelist_get */
+/** free file list allocated by call to redset_filelist_*_get */
 int redset_filelist_release(
   redset_filelist* plist /**< [INOUT] - address of pointer to list to be freed, sets pointer to NULL */
 );

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -267,22 +267,22 @@ int redset_unapply_rs(
 );
 
 
-redset_list* redset_filelist_get_single(
+redset_list* redset_filelist_enc_get_single(
   const char* name,
   redset_base* d
 );
 
-redset_list* redset_filelist_get_partner(
+redset_list* redset_filelist_enc_get_partner(
   const char* name,
   redset_base* d
 );
 
-redset_list* redset_filelist_get_xor(
+redset_list* redset_filelist_enc_get_xor(
   const char* name,
   redset_base* d
 );
 
-redset_list* redset_filelist_get_rs(
+redset_list* redset_filelist_enc_get_rs(
   const char* name,
   redset_base* d
 );

--- a/src/redset_internal.h
+++ b/src/redset_internal.h
@@ -287,6 +287,26 @@ redset_list* redset_filelist_get_rs(
   redset_base* d
 );
 
+redset_list* redset_filelist_orig_get_single(
+  const char* name,
+  const redset_base* d
+);
+
+redset_list* redset_filelist_orig_get_partner(
+  const char* name,
+  const redset_base* d
+);
+
+redset_list* redset_filelist_orig_get_xor(
+  const char* name,
+  const redset_base* d
+);
+
+redset_list* redset_filelist_orig_get_rs(
+  const char* name,
+  const redset_base* d
+);
+
 #ifdef HAVE_PTHREADS
 int redset_xor_encode_pthreads(
   const redset_base* d,

--- a/src/redset_lofi.h
+++ b/src/redset_lofi.h
@@ -52,6 +52,9 @@ int redset_lofi_apply_meta_mapped(kvtree* hash, const kvtree* map);
 /* given a hash that defines a set of files, apply metadata recorded to each file */
 int redset_lofi_apply_meta(kvtree* hash);
 
+/* given a hash that defines a set of files, return list of files */
+redset_filelist redset_lofi_filelist(const kvtree* hash);
+
 #ifdef __cplusplus
 } /* extern C */
 #endif

--- a/src/redset_partner.c
+++ b/src/redset_partner.c
@@ -24,7 +24,7 @@
 static void redset_build_partner_filename(
   const char* name,
   const redset_base* d,
-  char* file, 
+  char* file,
   size_t len)
 {
   int rank_world;
@@ -1044,5 +1044,24 @@ redset_list* redset_filelist_get_partner(
   list->count = 1;
   list->files = (const char**) REDSET_MALLOC(sizeof(char*));
   list->files[0] = strdup(file);
+  return list;
+}
+
+/* returns a list of original files encoded by redundancy descriptor */
+redset_list* redset_filelist_orig_get_partner(
+  const char* name,
+  const redset_base* d)
+{
+  redset_list* list = NULL;
+
+  /* check whether we have our files and our partner's files */
+  kvtree* header = kvtree_new();
+  if (redset_read_partner_file(name, d, header) == REDSET_SUCCESS) {
+    /* get pointer to hash for this rank */
+    kvtree* current_hash = kvtree_getf(header, "%s %d", REDSET_KEY_COPY_PARTNER_DESC, d->rank);
+    list = redset_lofi_filelist(current_hash);
+  }
+  kvtree_delete(&header);
+
   return list;
 }

--- a/src/redset_partner.c
+++ b/src/redset_partner.c
@@ -1034,7 +1034,7 @@ int redset_unapply_partner(
 }
 
 /* returns a list of files added by redundancy descriptor */
-redset_list* redset_filelist_get_partner(
+redset_list* redset_filelist_enc_get_partner(
   const char* name,
   redset_base* d)
 {

--- a/src/redset_reedsolomon.c
+++ b/src/redset_reedsolomon.c
@@ -1128,7 +1128,7 @@ int redset_unapply_rs(
 }
 
 /* returns a list of files added by redundancy descriptor */
-redset_list* redset_filelist_get_rs(
+redset_list* redset_filelist_enc_get_rs(
   const char* name,
   redset_base* d)
 {

--- a/src/redset_single.c
+++ b/src/redset_single.c
@@ -170,7 +170,7 @@ int redset_unapply_single(
 }
 
 /* returns a list of files added by redundancy descriptor */
-redset_list* redset_filelist_get_single(
+redset_list* redset_filelist_enc_get_single(
   const char* name,
   redset_base* d)
 {

--- a/src/redset_single.c
+++ b/src/redset_single.c
@@ -37,7 +37,7 @@
 static void redset_build_single_filename(
   const char* name,
   const redset_base* d,
-  char* file, 
+  char* file,
   size_t len)
 {
   int rank_world;
@@ -180,5 +180,24 @@ redset_list* redset_filelist_get_single(
   list->count = 1;
   list->files = (const char**) REDSET_MALLOC(sizeof(char*));
   list->files[0] = strdup(file);
+  return list;
+}
+
+/* returns a list of original files encoded by redundancy descriptor */
+redset_list* redset_filelist_orig_get_single(
+  const char* name,
+  const redset_base* d)
+{
+  redset_list* list = NULL;
+
+  /* check whether we have our files and our partner's files */
+  kvtree* header = kvtree_new();
+  if (redset_read_single_file(name, d, header) == REDSET_SUCCESS) {
+    /* get pointer to hash for this rank */
+    kvtree* current_hash = kvtree_getf(header, "%s %d", REDSET_KEY_COPY_SINGLE_DESC, d->rank);
+    list = redset_lofi_filelist(current_hash);
+  }
+  kvtree_delete(&header);
+
   return list;
 }

--- a/src/redset_xor.c
+++ b/src/redset_xor.c
@@ -45,7 +45,7 @@ static void reduce_xor(unsigned char* a, const unsigned char* b, size_t count)
 static void redset_build_xor_filename(
   const char* name,
   const redset_base* d,
-  char* file, 
+  char* file,
   size_t len)
 {
   int rank_world;
@@ -209,7 +209,7 @@ int redset_encode_reddesc_xor(
   /* exchange our redundancy descriptor hash with our partners */
   kvtree* partner_hash = kvtree_new();
   kvtree_sendrecv(hash, state->rhs_rank, partner_hash, state->lhs_rank, d->comm);
-   
+
   /* store partner hash in our under its name */
   kvtree_merge(hash, partner_hash);
   kvtree_delete(&partner_hash);
@@ -885,6 +885,25 @@ redset_filelist redset_filelist_get_data(
   }
 
   redset_free(&current_hashes);
+
+  return list;
+}
+
+/* returns a list of original files encoded by redundancy descriptor */
+redset_list* redset_filelist_orig_get_xor(
+  const char* name,
+  const redset_base* d)
+{
+  redset_list* list = NULL;
+
+  /* check whether we have our files and our partner's files */
+  kvtree* header = kvtree_new();
+  if (redset_read_xor_file(name, d, header) == REDSET_SUCCESS) {
+    /* get pointer to hash for this rank */
+    kvtree* current_hash = kvtree_getf(header, "%s %d", REDSET_KEY_COPY_XOR_DESC, d->rank);
+    list = redset_lofi_filelist(current_hash);
+  }
+  kvtree_delete(&header);
 
   return list;
 }

--- a/test/test_redset.c
+++ b/test/test_redset.c
@@ -253,7 +253,7 @@ int check_for_redundancy_files(int mode, const char* path, redset d)
   int rc = 0;
 
   /* get list of redundancy files */
-  redset_filelist list = redset_filelist_get(path, d);
+  redset_filelist list = redset_filelist_enc_get(path, d);
   if (list == NULL) {
     ABORT("Failed to get list of redundancy files");
   }
@@ -288,7 +288,7 @@ int delete_redundancy_files(int mode, const char* path, redset d)
   int rc = 0;
 
   /* get list of redundancy files */
-  redset_filelist list = redset_filelist_get(path, d);
+  redset_filelist list = redset_filelist_enc_get(path, d);
   if (list == NULL) {
     ABORT("Failed to get list of redundancy files");
   }
@@ -358,7 +358,7 @@ int test_unapply(int mode, const char* path, redset d, MPI_Comm comm)
   }
 
   /* get list of redundancy files */
-  redset_filelist list = redset_filelist_get(path, d);
+  redset_filelist list = redset_filelist_enc_get(path, d);
   if (list == NULL) {
     ABORT("Failed to get list of redundancy files");
   }


### PR DESCRIPTION
Given a ``name`` and redset descriptor ``d``, this adds a new ``redset_filelist_orig_get(name, d)`` API to return a ``redset_filelist`` object that lists the files that the caller provided to ``redset_apply(numfiles, files, name, d)``.

This is needed by the ``er`` component in order to restore a lost shuffile file during a rebuild operation: https://github.com/ECP-VeloC/er/issues/39